### PR TITLE
chore: don't log regalloc messages in ci

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -39,6 +39,8 @@ jobs:
           args: --release --workspace
       - name: test
         uses: actions-rs/cargo@v1
+        env:
+          RUST_LOG: info,regalloc=warn
         with:
           command: test
           args: --release --workspace


### PR DESCRIPTION
The regalloc messages printed (I assume when the parachain's wasm code is loaded) flooded the CI, making it harder to see the actual error messages