### PR TITLE
fix: transfer the expected refund amount

### DIFF
--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -138,7 +138,7 @@ impl Request {
             hash,
             deadline: None,
             btc_height: None,
-            amount: request.amount_btc,
+            amount: request.amount_wrapped,
             btc_address: request.btc_address,
             request_type: RequestType::Refund,
         }


### PR DESCRIPTION
This should fix the bug where a vault can get reported for theft for doing a refund. Not sure if we should merge already, or if we want to wait until we (1) remove `amount_btc` from the `refund` struct altogether, and (2) we have [these](https://www.notion.so/interlay/Add-integration-test-for-refund-theft-detection-interaction-7905826c7a954c11aedf82f7fc3e1f3d) integration tests