### PR TITLE
fix: also catch SubxtBasicErrors

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -112,6 +112,10 @@ impl Error {
             Error::SubxtRuntimeError(SubxtError::Rpc(RequestError::Call(CallError::Custom { code, message, .. })))
                 if *code == POOL_INVALID_TX &&
                 message == INVALID_TX_MESSAGE
+        ) || matches!(self,
+            Error::SubxtBasicError(BasicError::Rpc(RequestError::Call(CallError::Custom { code, message, .. })))
+                if *code == POOL_INVALID_TX &&
+                message == INVALID_TX_MESSAGE
         )
     }
 
@@ -123,11 +127,15 @@ impl Error {
         matches!(
             self,
             Error::SubxtRuntimeError(SubxtError::Rpc(JsonRpseeError::RestartNeeded(_)))
+                | Error::SubxtBasicError(BasicError::Rpc(JsonRpseeError::RestartNeeded(_)))
         )
     }
 
     pub fn is_rpc_error(&self) -> bool {
-        matches!(self, Error::SubxtRuntimeError(SubxtError::Rpc(_)))
+        matches!(
+            self,
+            Error::SubxtRuntimeError(SubxtError::Rpc(_)) | Error::SubxtBasicError(BasicError::Rpc(_))
+        )
     }
 
     pub fn is_ws_invalid_url_error(&self) -> bool {


### PR DESCRIPTION
Some of the errors apparently changed: rather than receiving `SubxtRuntimeError`, we now receive `SubxtBasicError`. Both of these are the same generic enum, only with different type instantiations: the basic error is guaranteed not to contain a runtime error. We might be able to get away with removing the old check, but to be safe I kept both versions.

This should fix:
- incorrect outdated nonce handling
- the vault getting stuck in an endless loop when the connection is lost