### PR TITLE
fix: outdated nonce check

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -113,9 +113,8 @@ impl Error {
                 if *code == POOL_INVALID_TX &&
                 message == INVALID_TX_MESSAGE
         ) || matches!(self,
-            Error::SubxtBasicError(BasicError::Rpc(RequestError::Call(CallError::Custom { code, message, .. })))
-                if *code == POOL_INVALID_TX &&
-                message == INVALID_TX_MESSAGE
+            Error::SubxtBasicError(BasicError::Rpc(RequestError::Request(message)))
+                if message.contains(OUTDATED_TX_MESSAGE) || message.contains(OUTDATED_TX_CODE) // check for both the error message and the code to be a little bit less brittle
         )
     }
 
@@ -170,4 +169,8 @@ pub enum KeyLoadingError {
 // https://github.com/paritytech/substrate/blob/e60597dff0aa7ffad623be2cc6edd94c7dc51edd/client/rpc-api/src/author/error.rs#L80
 const BASE_ERROR: i32 = 1000;
 const POOL_INVALID_TX: i32 = BASE_ERROR + 10;
+// a typical outdated nonce response would be:
+// {"jsonrpc":"2.0","error":{"code":1010,"message":"Invalid Transaction","data":"Transaction is outdated"},"id":628}"
 const INVALID_TX_MESSAGE: &str = "Invalid Transaction";
+const OUTDATED_TX_MESSAGE: &str = "Transaction is outdated";
+const OUTDATED_TX_CODE: &str = "\"code\":1010";


### PR DESCRIPTION
Back in https://github.com/interlay/interbtc-clients/pull/230 I changed the error checking. However, I did not check the outdated nonce error. It turns out that not only did it change from `SubxtRuntimeError` to `SubxtBasicError`, the inner error also changed from `RequestError::Call` to `RequestError::Request` due to a change in jsonrpsee. Annoyingly, this error only contains an error message string and not any error code, so we have to search for the error string.. 

Anyway, the incorrect outdated nonce detection caused request_replace to fail, since a transaction would be made from the ui, thus causing the nonce to be outdated. The vault client gave up after one try, which we do on purpose (on disconnect the client would restart), but I still think we should have a careful look at error handling robustness sometime soon