### PR TITLE
fix: request execution on startup should not use walletless btc rpc

### DIFF
--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -326,6 +326,7 @@ impl VaultService {
 
         let open_request_executor = execute_open_requests(
             self.btc_parachain.clone(),
+            self.vault_id_manager.clone(),
             walletless_btc_rpc.clone(),
             num_confirmations,
             self.config.payment_margin_minutes,


### PR DESCRIPTION
Startup request execution used a walletless bitcoin rpc connection, and failed because of that. Now we use the correct connections