### PR TITLE
chore: remove incorrect todo comment on theft reporting startup

### DIFF
--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -618,8 +618,8 @@ impl VaultService {
         tracing::info!("Got new block...");
         Ok(startup_height)
     }
+
     pub(crate) async fn start_theft_reporting(&self) -> Result<impl Future, Error> {
-        // TODO: don't fetch vaults if reporting is disabled
         tracing::info!("Fetching all active vaults...");
         let vaults = self
             .btc_parachain


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Subroutine is already guarded by `maybe_run_task`.