### PR TITLE
fix: cancel all spawned tasks

### DIFF
--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -325,6 +325,7 @@ impl VaultService {
         let startup_height = self.await_parachain_block().await?;
 
         let open_request_executor = execute_open_requests(
+            self.shutdown.clone(),
             self.btc_parachain.clone(),
             self.vault_id_manager.clone(),
             walletless_btc_rpc.clone(),
@@ -414,6 +415,7 @@ impl VaultService {
         let accept_replace_listener = wait_or_shutdown(
             self.shutdown.clone(),
             listen_for_accept_replace(
+                self.shutdown.clone(),
                 self.btc_parachain.clone(),
                 self.vault_id_manager.clone(),
                 num_confirmations,
@@ -464,6 +466,7 @@ impl VaultService {
         let redeem_listener = wait_or_shutdown(
             self.shutdown.clone(),
             listen_for_redeem_requests(
+                self.shutdown.clone(),
                 self.btc_parachain.clone(),
                 self.vault_id_manager.clone(),
                 num_confirmations,
@@ -475,6 +478,7 @@ impl VaultService {
         let refund_listener = wait_or_shutdown(
             self.shutdown.clone(),
             listen_for_refund_requests(
+                self.shutdown.clone(),
                 self.btc_parachain.clone(),
                 self.vault_id_manager.clone(),
                 num_confirmations,


### PR DESCRIPTION
When we restarted the service (because of disconnect for example), we made sure to cancel the running services. However, we didn't cancel the tasks that were spawned for e.g. executing a redeem. So we start, see an open redeem, and spawn another task to pay and execute the redeem. But if you were unlucky with timing (i.e. first task didn't yet submit the payment to bitcoin core), both tasks could do the payment. 

This pr makes all spawned tasks listen for the shutdown signal.