### PR TITLE
fix: retry when transaction does not get included due to fork

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -18,7 +18,7 @@ use std::{
     io::Error as IoError,
     num::TryFromIntError,
 };
-use subxt::{sp_core::crypto::SecretStringError, BasicError};
+use subxt::{sp_core::crypto::SecretStringError, BasicError, TransactionError};
 use thiserror::Error;
 use tokio::time::error::Elapsed;
 use url::ParseError as UrlParseError;
@@ -47,6 +47,8 @@ pub enum Error {
     ChannelClosed,
     #[error("Cannot replace existing transaction")]
     PoolTooLowPriority,
+    #[error("Transaction did not get included - block hash not found")]
+    BlockHashNotFound,
     #[error("Transaction is invalid: {0}")]
     InvalidTransaction(String),
     #[error("Request has timed out")]
@@ -238,6 +240,15 @@ impl Error {
         matches!(
             self,
             Error::SubxtRuntimeError(OuterSubxtError(SubxtError::Rpc(_))) | Error::SubxtBasicError(BasicError::Rpc(_))
+        )
+    }
+
+    pub fn is_block_hash_not_found_error(&self) -> bool {
+        matches!(
+            self,
+            Error::SubxtRuntimeError(OuterSubxtError(SubxtError::Transaction(
+                TransactionError::BlockHashNotFound
+            ))) | Error::SubxtBasicError(BasicError::Transaction(TransactionError::BlockHashNotFound))
         )
     }
 

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -160,6 +160,10 @@ impl InterBtcParachain {
                         } else if err.is_pool_too_low_priority().is_some() {
                             self.refresh_nonce().await;
                             Err(RetryPolicy::Skip(Error::PoolTooLowPriority))
+                        } else if err.is_block_hash_not_found_error() {
+                            self.refresh_nonce().await;
+                            log::info!("Re-sending transaction after apparent fork");
+                            Err(RetryPolicy::Skip(Error::BlockHashNotFound))
                         } else {
                             Err(RetryPolicy::Throw(err))
                         }


### PR DESCRIPTION
This should fix the `Subxt runtime error: Transaction error: The block containing the transaction can no longer be found (perhaps it was on a non-finalized fork?` error