### PR TITLE
fix: add timeout on transaction submission

### DIFF
--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -64,7 +64,9 @@ async fn main() -> Result<(), Error> {
     let faucet_config = opts.faucet;
 
     loop {
-        let btc_parachain = parachain_config.try_connect(signer.clone()).await?;
+        let btc_parachain = parachain_config
+            .try_connect(signer.clone(), shutdown_tx.clone())
+            .await?;
 
         let close_handle = http::start_http(
             btc_parachain.clone(),

--- a/oracle/src/main.rs
+++ b/oracle/src/main.rs
@@ -229,9 +229,14 @@ async fn main() -> Result<(), Error> {
         .collect();
 
     loop {
-        let parachain_rpc =
-            InterBtcParachain::from_url_with_retry(&opts.btc_parachain_url, signer.clone(), opts.connection_timeout_ms)
-                .await?;
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+        let parachain_rpc = InterBtcParachain::from_url_with_retry(
+            &opts.btc_parachain_url,
+            signer.clone(),
+            opts.connection_timeout_ms,
+            shutdown_tx,
+        )
+        .await?;
 
         let bitcoin_fee = opts.bitcoin_fee;
 

--- a/runtime/src/cli.rs
+++ b/runtime/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::{Error, KeyLoadingError},
+    rpc::ShutdownSender,
     InterBtcParachain, InterBtcSigner,
 };
 use clap::Parser;
@@ -89,13 +90,18 @@ pub struct ConnectionOpts {
 }
 
 impl ConnectionOpts {
-    pub async fn try_connect(&self, signer: InterBtcSigner) -> Result<InterBtcParachain, Error> {
+    pub async fn try_connect(
+        &self,
+        signer: InterBtcSigner,
+        shutdown_tx: ShutdownSender,
+    ) -> Result<InterBtcParachain, Error> {
         InterBtcParachain::from_url_and_config_with_retry(
             &self.btc_parachain_url,
             signer,
             self.max_concurrent_requests,
             self.max_notifs_per_subscription,
             self.btc_parachain_connection_timeout_ms,
+            shutdown_tx,
         )
         .await
     }

--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -89,7 +89,9 @@ pub async fn default_provider_client(key: AccountKeyring) -> (SubxtClient, TempD
 /// Create a new parachain_rpc with the given keyring
 pub async fn setup_provider(client: SubxtClient, key: AccountKeyring) -> InterBtcParachain {
     let signer = InterBtcSigner::new(key.pair());
-    InterBtcParachain::new(client, signer)
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+
+    InterBtcParachain::new(client, signer, shutdown_tx)
         .await
         .expect("Error creating parachain_rpc")
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -89,6 +89,7 @@ impl<Config: Clone + Send + 'static, S: Service<Config>> ConnectionManager<Confi
                 self.parachain_config.max_concurrent_requests,
                 self.parachain_config.max_notifs_per_subscription,
                 self.parachain_config.btc_parachain_connection_timeout_ms,
+                shutdown_tx.clone(),
             )
             .await?;
 


### PR DESCRIPTION
This adds a 5 minute timeout on all transaction submissions. Since I am not sure of subxt/jsonrpsee deals well with cancelled subscriptions, and because a timeout might indicate an invalid state in those dependencies, I made _all_ timeouts fire the shutdown signal so a fresh connection will get established upon restart. Without this explicit shutdown signal, non-essential calls (such as bitcoin block relay) would not cause a restart.

The reason for the long timeout time is so that it's less likely the stuck transaction will get included into the parachain after we timeout.