### PR TITLE
Fix: dont fail when processing tx containing taproot outputs

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -605,8 +605,8 @@ impl BitcoinCoreApi for BitcoinCore {
         let txids = self.rpc.get_raw_mempool()?;
         // map txid to the actual Transaction structs
         let iterator = txids.into_iter().filter_map(move |txid| {
-            match self.rpc.get_raw_transaction_info(&txid, None) {
-                Ok(x) => Some(x.transaction().map_err(Into::into)),
+            match self.rpc.get_raw_transaction(&txid, None) {
+                Ok(x) => Some(Ok(x)),
                 Err(e) if err_not_in_mempool(&e) => None, // not in mempool anymore, so filter out
                 Err(e) => Some(Err(e.into())),            // unknown error, propagate to user
             }


### PR DESCRIPTION
`get_raw_transaction_info` failed when called on a tx that contained a taproot output. This happened when we scanned the mempool for unexecuted redeems upon startup. The underlying cause is that the bitcoin crate does not support taproot yet - this is supposed to come in version 0.28 (wip at time of writing):
https://github.com/rust-bitcoin/rust-bitcoin/milestone/10 
https://github.com/orgs/rust-bitcoin/projects/3 

The fix is to not use `get_raw_transaction_info`, but rather `get_raw_transaction`, which I confirmed _does_ work, and is anyway all we need.

The second change is to not abort processing redeem/replace/refunds when we _do_ fail to parse a specific transaction. 

For future reference, the failing info can be obtained with `bitcoin-cli getrawtransaction fd760221293e6a962393265acd628fa203e1c2cf564e380952ae314b1ff1fd2a true 00000000000000000009739415969cfc10554ce10c073fef0894b0db84417197`. A unit test can be set up with `let result: GetRawTransactionResult = serde_json::from_str(json).unwrap();`, where `json` is the output of the `getrawtransaction` call.