### PR TITLE
fix: prevent rescanblockchain timeouts by splitting the scan into chunks

### DIFF
--- a/bitcoin/src/iter.rs
+++ b/bitcoin/src/iter.rs
@@ -242,7 +242,7 @@ mod tests {
                 where
                     P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), Error>;
-            async fn rescan_blockchain(&self, start_height: usize) -> Result<(), Error>;
+            async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, Error>;
             fn get_utxo_count(&self) -> Result<usize, Error>;
         }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -174,7 +174,7 @@ pub trait BitcoinCoreApi {
 
     async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), Error>;
 
-    async fn rescan_blockchain(&self, start_height: usize) -> Result<(), Error>;
+    async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error>;
 
     async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, Error>;
 
@@ -805,8 +805,8 @@ impl BitcoinCoreApi for BitcoinCore {
             .await
     }
 
-    async fn rescan_blockchain(&self, start_height: usize) -> Result<(), Error> {
-        self.rpc.rescan_blockchain(Some(start_height), None)?;
+    async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error> {
+        self.rpc.rescan_blockchain(Some(start_height), Some(end_height))?;
         Ok(())
     }
 

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -521,7 +521,7 @@ impl BitcoinCoreApi for MockBitcoinCore {
     async fn import_private_key(&self, _privkey: PrivateKey) -> Result<(), BitcoinError> {
         Ok(())
     }
-    async fn rescan_blockchain(&self, start_height: usize) -> Result<(), BitcoinError> {
+    async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError> {
         Ok(())
     }
     async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError> {

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -680,7 +680,7 @@ mod tests {
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn wallet_has_public_key<P>(&self, public_key: P) -> Result<bool, BitcoinError> where P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
-            async fn rescan_blockchain(&self, start_height: usize) -> Result<(), BitcoinError>;
+            async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
         }

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -9,6 +9,10 @@ use service::Error as ServiceError;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
+// we have seen scanning rates as low as 61 blocks/s. Process 100 blocks per time so that we
+// don't run into the 15 s timeout.
+const SCAN_CHUNK_SIZE: usize = 100;
+
 // initialize `issue_set` with currently open issues, and return the block height
 // from which to start watching the bitcoin chain
 pub(crate) async fn initialize_issue_set<B: BitcoinCoreApi + Clone + Send + Sync + 'static>(
@@ -82,13 +86,25 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
         }
     }
 
+    // read height only _after_ the last add_new_deposit_height.If a new block arrives
+    // while we rescan, bitcoin core will correctly recognize addressed associated with the
+    // privkey
+    let btc_end_height = bitcoin_core.get_block_count().await? as usize - 1;
+
     tracing::info!("Rescanning bitcoin chain from height {}...", btc_start_height);
-    if let Err(err) = bitcoin_core.rescan_blockchain(btc_start_height).await {
-        // invalid start height or other
-        tracing::error!("Unable to rescan blockchain: {}", err);
+    for (range_start, range_end) in chunks(btc_start_height, btc_end_height) {
+        tracing::debug!("Scanning chain blocks {range_start}-{range_end}...");
+        bitcoin_core.rescan_blockchain(range_start, range_end).await?;
     }
 
     Ok(())
+}
+
+/// Return the chunks of size SCAN_CHUNK_SIZE from first..last (including).
+fn chunks(first: usize, last: usize) -> impl Iterator<Item = (usize, usize)> {
+    (first..last)
+        .step_by(SCAN_CHUNK_SIZE)
+        .map(move |x| (x, usize::min(x + SCAN_CHUNK_SIZE - 1, last)))
 }
 
 /// execute issue requests with a matching Bitcoin payment
@@ -303,4 +319,15 @@ pub async fn listen_for_issue_cancels(
         )
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chunks() {
+        let result: Vec<_> = chunks(50, 316).collect();
+        assert_eq!(result, vec![(50, 149), (150, 249), (250, 316)]);
+    }
 }

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -285,7 +285,7 @@ mod tests {
                 where
                     P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
-            async fn rescan_blockchain(&self, start_height: usize) -> Result<(), BitcoinError>;
+            async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
         }

--- a/vault/src/vaults.rs
+++ b/vault/src/vaults.rs
@@ -375,7 +375,7 @@ mod tests {
                 where
                     P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
-            async fn rescan_blockchain(&self, start_height: usize) -> Result<(), BitcoinError>;
+            async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
         }


### PR DESCRIPTION
Apparently there is a 15 second timeout on the bitcoin core requests. For one user, it took about 16 seconds, so the request would timeout, causing the connection to drop and the service to restart. This fix splits scanning into discrete chunks of 100 blocks so we don't run into the timeout. It would be possible to dynamically adjust the chunk size based on the time it takes on a specific machine but I thought it best to keep it as simple as possible. Also note that increasing the timeout wouldn't be a solution, as the expected scan time will only increase for each new mined block.