### PR TITLE
chore: vault should use tracing for exit error

### DIFF
--- a/vault/src/main.rs
+++ b/vault/src/main.rs
@@ -78,7 +78,7 @@ async fn start() -> Result<(), Error> {
 #[tokio::main]
 async fn main() {
     let exit_code = if let Err(err) = start().await {
-        eprintln!("Error: {}", err);
+        tracing::error!("Exiting: {}", err);
         1
     } else {
         0


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>