### PR TITLE
fix: don't import key of other vault currencies on startup

### DIFF
--- a/vault/src/cancellation.rs
+++ b/vault/src/cancellation.rs
@@ -690,7 +690,7 @@ mod tests {
         // check that if the selector fails, the error is propagated
         let parachain_rpc = MockProvider::default();
 
-        let mut cancellation_scheduler = CancellationScheduler::new(parachain_rpc, 0, 0, AccountId::new([1u8; 32]));
+        let cancellation_scheduler = CancellationScheduler::new(parachain_rpc, 0, 0, AccountId::new([1u8; 32]));
 
         // dropping the tx immediately - this effectively closes the channel
         let (_, replace_event_rx) = mpsc::channel::<Event>(16);

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -236,7 +236,7 @@ impl<BCA: BitcoinCoreApi + Clone + Send + Sync + 'static> VaultIdManager<BCA> {
         }
 
         tracing::info!("Adding keys from past issues...");
-        issue::add_keys_from_past_issue_request(&btc_rpc, &self.btc_parachain).await?;
+        issue::add_keys_from_past_issue_request(&btc_rpc, &self.btc_parachain, &vault_id).await?;
 
         tracing::info!("Initializing metrics...");
         let metrics = PerCurrencyMetrics::new(&vault_id);

--- a/vault/tests/vault_integration_tests.rs
+++ b/vault/tests/vault_integration_tests.rs
@@ -307,10 +307,6 @@ async fn test_report_vault_double_payment_succeeds() {
     .await;
 }
 
-async fn get_master_btc_rpc(parachain_rpc: InterBtcParachain) -> MockBitcoinCore {
-    let btc_rpc = MockBitcoinCore::new(parachain_rpc).await;
-    btc_rpc
-}
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redeem_succeeds() {
     test_with_vault(|client, vault_id, vault_provider| async move {
@@ -647,13 +643,13 @@ async fn test_cancellation_succeeds() {
             issue_set.clone(),
         );
 
-        let mut issue_cancellation_scheduler = vault::service::CancellationScheduler::new(
+        let issue_cancellation_scheduler = vault::service::CancellationScheduler::new(
             new_vault_provider.clone(),
             new_vault_provider.get_current_chain_height().await.unwrap(),
             0,
             new_vault_provider.get_account_id().clone(),
         );
-        let mut replace_cancellation_scheduler = vault::service::CancellationScheduler::new(
+        let replace_cancellation_scheduler = vault::service::CancellationScheduler::new(
             new_vault_provider.clone(),
             new_vault_provider.get_current_chain_height().await.unwrap(),
             0,


### PR DESCRIPTION
Upon restart, the vault would import keys from past issues but it imported the keys from all vault currencies, which led to thefts