### PR TITLE
Define a "feature specific" default value for ConnectionOpts.btc_para…

### DIFF
--- a/runtime/src/cli.rs
+++ b/runtime/src/cli.rs
@@ -74,9 +74,10 @@ pub fn parse_duration_minutes(src: &str) -> Result<Duration, ParseIntError> {
 pub struct ConnectionOpts {
     /// Parachain websocket URL.
     #[cfg_attr(feature = "standalone-metadata",clap(long, default_value = "ws://127.0.0.1:9944"))]
-    #[cfg_attr(feature = "parachain-metadata-testnet",clap(long, default_value = "wss://api-testnet.interlay.io:443/parachain"))]
+    #[cfg_attr(feature = "parachain-metadata-interlay-testnet",clap(long, default_value = "wss://staging.interlay-dev.interlay.io:443/parachain"))]
+    #[cfg_attr(feature = "parachain-metadata-kintsugi-testnet",clap(long, default_value = "wss://api-dev-kintsugi.interlay.io:443/parachain"))]
     #[cfg_attr(feature = "parachain-metadata-kintsugi",clap(long, default_value = "wss://api-kusama.interlay.io:443/parachain"))]
-    #[cfg_attr(feature = "parachain-metadata-interlay",clap(long, default_value = "ws://127.0.0.1:9944"))]
+    #[cfg_attr(feature = "parachain-metadata-interlay",clap(long, default_value = "wss://api.interlay.io:443/parachain"))]
     pub btc_parachain_url: String,
 
     /// Timeout in milliseconds to wait for connection to btc-parachain.

--- a/runtime/src/cli.rs
+++ b/runtime/src/cli.rs
@@ -73,7 +73,10 @@ pub fn parse_duration_minutes(src: &str) -> Result<Duration, ParseIntError> {
 #[derive(Parser, Debug, Clone)]
 pub struct ConnectionOpts {
     /// Parachain websocket URL.
-    #[clap(long, default_value = "ws://127.0.0.1:9944")]
+    #[cfg_attr(feature = "standalone-metadata",clap(long, default_value = "ws://127.0.0.1:9944"))]
+    #[cfg_attr(feature = "parachain-metadata-testnet",clap(long, default_value = "wss://api-testnet.interlay.io:443/parachain"))]
+    #[cfg_attr(feature = "parachain-metadata-kintsugi",clap(long, default_value = "wss://api-kusama.interlay.io:443/parachain"))]
+    #[cfg_attr(feature = "parachain-metadata-interlay",clap(long, default_value = "ws://127.0.0.1:9944"))]
     pub btc_parachain_url: String,
 
     /// Timeout in milliseconds to wait for connection to btc-parachain.

--- a/runtime/src/cli.rs
+++ b/runtime/src/cli.rs
@@ -73,11 +73,23 @@ pub fn parse_duration_minutes(src: &str) -> Result<Duration, ParseIntError> {
 #[derive(Parser, Debug, Clone)]
 pub struct ConnectionOpts {
     /// Parachain websocket URL.
-    #[cfg_attr(feature = "standalone-metadata",clap(long, default_value = "ws://127.0.0.1:9944"))]
-    #[cfg_attr(feature = "parachain-metadata-interlay-testnet",clap(long, default_value = "wss://staging.interlay-dev.interlay.io:443/parachain"))]
-    #[cfg_attr(feature = "parachain-metadata-kintsugi-testnet",clap(long, default_value = "wss://api-dev-kintsugi.interlay.io:443/parachain"))]
-    #[cfg_attr(feature = "parachain-metadata-kintsugi",clap(long, default_value = "wss://api-kusama.interlay.io:443/parachain"))]
-    #[cfg_attr(feature = "parachain-metadata-interlay",clap(long, default_value = "wss://api.interlay.io:443/parachain"))]
+    #[cfg_attr(feature = "standalone-metadata", clap(long, default_value = "ws://127.0.0.1:9944"))]
+    #[cfg_attr(
+        feature = "parachain-metadata-interlay-testnet",
+        clap(long, default_value = "wss://staging.interlay-dev.interlay.io:443/parachain")
+    )]
+    #[cfg_attr(
+        feature = "parachain-metadata-kintsugi-testnet",
+        clap(long, default_value = "wss://api-dev-kintsugi.interlay.io:443/parachain")
+    )]
+    #[cfg_attr(
+        feature = "parachain-metadata-kintsugi",
+        clap(long, default_value = "wss://api-kusama.interlay.io:443/parachain")
+    )]
+    #[cfg_attr(
+        feature = "parachain-metadata-interlay",
+        clap(long, default_value = "wss://api.interlay.io:443/parachain")
+    )]
     pub btc_parachain_url: String,
 
     /// Timeout in milliseconds to wait for connection to btc-parachain.


### PR DESCRIPTION
…chain_url

Define a "feature specific" default value for the btc_parachain_url command line parameter of structure ConnectionOpts using the cfg_attr directive .
By providing a default url for testnet/kintsugi/interlay, the user will not have to provide this parameter in the command line