### PR TITLE
fix: do not lock additional collateral when accepting replace request

### DIFF
--- a/vault/src/error.rs
+++ b/vault/src/error.rs
@@ -10,8 +10,6 @@ use thiserror::Error;
 pub enum Error {
     #[error("Insufficient funds available")]
     InsufficientFunds,
-    #[error("Value below dust amount")]
-    BelowDustAmount,
     #[error("Failed to load or create bitcoin wallet: {0}")]
     WalletInitializationFailure(BitcoinError),
     #[error("Transaction contains more than one return-to-self uxto")]


### PR DESCRIPTION
As discussed on discord, we shouldn't lock additional collateral when accepting a replace request because of the following reasons:

- the vault shouldn't lock additional collateral without the operator's explicit consent
- when we are at the collateral ceiling, all accept_replace calls fail with CurrencyCeilingExceeded
- it fails in the common case where there is no additional collateral available to add in the vault's account

One thing to note is that I removed the `BelowDustAmount` check, which was incorrectly implemented: it was comparing a collateral currency against a wrapped currency, which obviously is incorrect. Furthermore, we already check for dust amount in the parachain so no need to check again in the client.