### PR TITLE
feat: fail to start on metadata mismatch

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -55,6 +55,8 @@ pub enum Error {
     InsufficientFunds,
     #[error("Client does not support spec_version: expected {0}, got {1}")]
     InvalidSpecVersion(u32, u32),
+    #[error("Client metadata is different from parachain metadata: expected {0}, got {1}")]
+    ParachainMetadataMismatch(String, String),
     #[error("Failed to load credentials from file: {0}")]
     KeyLoadingFailure(#[from] KeyLoadingError),
     #[error("Error serializing: {0}")]

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -74,16 +74,15 @@ impl InterBtcParachain {
         let api: RuntimeApi = ext_client.clone().to_runtime_api();
 
         let runtime_version = ext_client.rpc().runtime_version(None).await?;
-        if let Some(spec_name) = runtime_version.other.get("specName") {
-            if spec_name == DEFAULT_SPEC_NAME {
-                log::info!("spec_name={}", spec_name);
-            } else {
-                return Err(Error::ParachainMetadataMismatch(
-                    DEFAULT_SPEC_NAME.into(),
-                    // The spec name is always expected to be a string if defined, so `unwrap()` never panics.
-                    spec_name.as_str().unwrap().into(),
-                ));
-            }
+        let default_spec_name = &Value::default();
+        let spec_name = runtime_version.other.get("specName").unwrap_or(default_spec_name);
+        if spec_name == DEFAULT_SPEC_NAME {
+            log::info!("spec_name={}", spec_name);
+        } else {
+            return Err(Error::ParachainMetadataMismatch(
+                DEFAULT_SPEC_NAME.into(),
+                spec_name.as_str().unwrap_or_default().into(),
+            ));
         }
 
         if runtime_version.spec_version == DEFAULT_SPEC_VERSION {


### PR DESCRIPTION
Adds declaration of `DEFAULT_SPEC_NAME` constant based on the metadata used for compiling. When connecting to a chain, the clients shut down if the chain `spec_name` does not match `DEFAULT_SPEC_NAME`, printing an error message.