### PR TITLE
feat: fail to start with wrong bitcoin network

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -55,6 +55,10 @@ pub enum Error {
     InsufficientFunds,
     #[error("Client does not support spec_version: expected {0}, got {1}")]
     InvalidSpecVersion(u32, u32),
+    #[error("Client metadata is different from parachain metadata: expected {0}, got {1}")]
+    ParachainMetadataMismatch(String, String),
+    #[error("Specified Bitcoin network differs from the one on the parachain: expected {0}, got {1}")]
+    BitcoinNetworkMismatch(String, String),
     #[error("Failed to load credentials from file: {0}")]
     KeyLoadingFailure(#[from] KeyLoadingError),
     #[error("Error serializing: {0}")]

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -372,6 +372,8 @@ pub trait UtilFuncs {
     /// Gets the current height of the parachain
     async fn get_current_chain_height(&self) -> Result<u32, Error>;
 
+    async fn get_rpc_properties(&self) -> Result<Map<String, Value>, Error>;
+
     /// Gets the ID of the native currency.
     fn get_native_currency_id(&self) -> CurrencyId;
 
@@ -386,6 +388,10 @@ impl UtilFuncs for InterBtcParachain {
     async fn get_current_chain_height(&self) -> Result<u32, Error> {
         let head = self.get_latest_block_hash().await?;
         Ok(self.api.storage().system().number(head).await?)
+    }
+
+    async fn get_rpc_properties(&self) -> Result<Map<String, Value>, Error> {
+        Ok(self.ext_client.rpc().system_properties().await?)
     }
 
     fn get_native_currency_id(&self) -> CurrencyId {

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -388,7 +388,7 @@ pub trait UtilFuncs {
     /// Gets the current height of the parachain
     async fn get_current_chain_height(&self) -> Result<u32, Error>;
 
-    async fn get_rpc_properties(&self) -> Result<Map<String, Value>, Error>;
+    async fn get_rpc_properties(&self) -> Result<serde_json::Map<String, Value>, Error>;
 
     /// Gets the ID of the native currency.
     fn get_native_currency_id(&self) -> CurrencyId;
@@ -406,7 +406,7 @@ impl UtilFuncs for InterBtcParachain {
         Ok(self.api.storage().system().number(head).await?)
     }
 
-    async fn get_rpc_properties(&self) -> Result<Map<String, Value>, Error> {
+    async fn get_rpc_properties(&self) -> Result<serde_json::Map<String, Value>, Error> {
         Ok(self.ext_client.rpc().system_properties().await?)
     }
 

--- a/vault/src/cancellation.rs
+++ b/vault/src/cancellation.rs
@@ -318,6 +318,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use futures::channel::mpsc;
+    use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
         AccountId, BtcAddress, BtcPublicKey, CurrencyId, ErrorCode, InterBtcIssueRequest, InterBtcReplaceRequest,
         IssueRequestStatus, RequestIssueEvent, StatusCode, Token, VaultId, DOT, IBTC,
@@ -366,6 +367,7 @@ mod tests {
         #[async_trait]
         pub trait UtilFuncs {
             async fn get_current_chain_height(&self) -> Result<u32, RuntimeError>;
+            async fn get_rpc_properties(&self) -> Result<Map<String, Value>, RuntimeError>;
             fn get_native_currency_id(&self) -> CurrencyId;
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -545,6 +545,7 @@ mod tests {
         json, Amount, Block, BlockHash, BlockHeader, Error as BitcoinError, GetBlockResult, LockedTransaction, Network,
         PartialAddress, PrivateKey, Transaction, TransactionMetadata, Txid, PUBLIC_KEY_SIZE,
     };
+    use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
         AccountId, BlockNumber, BtcPublicKey, CurrencyId, Error as RuntimeError, ErrorCode, InterBtcRichBlockHeader,
         InterBtcVault, StatusCode, Token, DOT, IBTC,
@@ -571,6 +572,7 @@ mod tests {
         #[async_trait]
         pub trait UtilFuncs {
             async fn get_current_chain_height(&self) -> Result<u32, RuntimeError>;
+            async fn get_rpc_properties(&self) -> Result<Map<String, Value>, RuntimeError>;
             fn get_native_currency_id(&self) -> CurrencyId;
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -690,6 +690,7 @@ mod tests {
         json, Amount, Block, BlockHash, BlockHeader, Error as BitcoinError, GetBlockResult, LockedTransaction, Network,
         PartialAddress, PrivateKey, Transaction, TransactionMetadata, Txid, PUBLIC_KEY_SIZE,
     };
+    use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
         AccountId, Balance, BlockNumber, BtcAddress, BtcPublicKey, CurrencyId, Error as RuntimeError, ErrorCode,
         InterBtcIssueRequest, InterBtcRedeemRequest, InterBtcRefundRequest, InterBtcReplaceRequest, InterBtcVault,
@@ -703,6 +704,7 @@ mod tests {
         #[async_trait]
         pub trait UtilFuncs {
             async fn get_current_chain_height(&self) -> Result<u32, RuntimeError>;
+            async fn get_rpc_properties(&self) -> Result<Map<String, Value>, RuntimeError>;
             fn get_native_currency_id(&self) -> CurrencyId;
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -17,6 +17,7 @@ use futures::{
     Future, SinkExt, TryFutureExt,
 };
 use git_version::git_version;
+use jsonrpc_core::Value;
 use runtime::{
     cli::{parse_duration_minutes, parse_duration_ms},
     parse_collateral_currency, BtcRelayPallet, CollateralBalancesPallet, CurrencyId, Error as RuntimeError,
@@ -478,7 +479,30 @@ impl VaultService {
         }
     }
 
+    async fn ensure_bitcoin_networks_match(&self) -> Result<(), Error> {
+        let bitcoin_network = self.btc_rpc_master_wallet.network().to_string();
+        let default_spec_bitcoin_network = &Value::default();
+        let system_properties = self.btc_parachain.get_rpc_properties().await.unwrap_or_default();
+        let parachain_bitcoin_network = system_properties
+            .get("bitcoinNetwork")
+            .unwrap_or(default_spec_bitcoin_network)
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+
+        // `parachain_bitcoin_network` can be `bitcoin-mainnet`, `bitcoin-testnet`, or `bitcoin-regtest`
+        // source: https://github.com/interlay/interbtc/blob/a71b970616b0a4a59cd2e709a606a9a78fce80ff/primitives/src/lib.rs#L23
+        // `bitcoin_network` can be `mainnet`, `testnet`, regtest.
+        // source: https://developer.bitcoin.org/reference/rpc/getblockchaininfo.html
+        if !parachain_bitcoin_network.contains(&bitcoin_network) {
+            return Err(runtime::Error::BitcoinNetworkMismatch(parachain_bitcoin_network, bitcoin_network).into());
+        }
+        Ok(())
+    }
+
     async fn run_service(&self) -> Result<(), Error> {
+        self.ensure_bitcoin_networks_match().await?;
+
         let account_id = self.btc_parachain.get_account_id().clone();
 
         // exit if auto-register uses faucet and faucet url not set


### PR DESCRIPTION
Ensures that the `bitcoinNetwork` RPC property specified on the chain matches the chain name returned by `getblockchaininfo` (`mainnet`, `testnet`, `regtest`).