### PR TITLE
feat: enable RBF on all transactions

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -397,6 +397,8 @@ impl BitcoinCore {
         let args = [
             serde_json::to_value::<&[json::CreateRawTransactionInput]>(&[])?,
             serde_json::to_value(outputs)?,
+            serde_json::to_value(0i64)?, /* locktime - default 0: see https://developer.bitcoin.org/reference/rpc/createrawtransaction.html */
+            serde_json::to_value(true)?, // BIP125-replaceable, aka Replace By Fee (RBF)
         ];
         Ok(self.rpc.call("createrawtransaction", &args)?)
     }


### PR DESCRIPTION
In the future we will want to add some support to do automatically increase the fee after a certain period, but for now this at least gives us the option to manually do it