### PR TITLE
feat: explicitly use oracle's bitcoin fees in tx funding

### DIFF
--- a/bitcoin/src/iter.rs
+++ b/bitcoin/src/iter.rs
@@ -223,6 +223,7 @@ mod tests {
                 &self,
                 address: A,
                 sat: u64,
+                fee_rate: u64,
                 request_id: Option<H256>,
             ) -> Result<LockedTransaction, Error>;
             async fn send_transaction(&self, transaction: LockedTransaction) -> Result<Txid, Error>;
@@ -230,6 +231,7 @@ mod tests {
                 &self,
                 address: A,
                 sat: u64,
+                fee_rate: u64,
                 request_id: Option<H256>,
             ) -> Result<Txid, Error>;
             async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(
@@ -237,6 +239,7 @@ mod tests {
                 address: A,
                 sat: u64,
                 request_id: Option<H256>,
+                fee_rate: u64,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, Error>;
             async fn create_or_load_wallet(&self) -> Result<(), Error>;

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -264,6 +264,7 @@ impl MockBitcoinCore {
         address: A,
         sat: u64,
         request_id: Option<H256>,
+        fee_rate: u64,
         num_confirmations: u32,
     ) -> Result<TransactionMetadata, BitcoinError> {
         let tx = self
@@ -463,6 +464,7 @@ impl BitcoinCoreApi for MockBitcoinCore {
         &self,
         address: A,
         sat: u64,
+        _fee_rate: u64, // ignored in this impl
         request_id: Option<H256>,
     ) -> Result<LockedTransaction, BitcoinError> {
         let mut transaction = MockBitcoinCore::generate_normal_transaction(&address, sat);
@@ -493,9 +495,10 @@ impl BitcoinCoreApi for MockBitcoinCore {
         &self,
         address: A,
         sat: u64,
+        fee_rate: u64,
         request_id: Option<H256>,
     ) -> Result<Txid, BitcoinError> {
-        let tx = self.create_transaction(address, sat, request_id).await?;
+        let tx = self.create_transaction(address, sat, fee_rate, request_id).await?;
         let txid = self.send_transaction(tx).await?;
         Ok(txid)
     }
@@ -504,10 +507,11 @@ impl BitcoinCoreApi for MockBitcoinCore {
         address: A,
         sat: u64,
         request_id: Option<H256>,
+        fee_rate: u64,
         num_confirmations: u32,
     ) -> Result<TransactionMetadata, BitcoinError> {
         let txid = self
-            .create_and_send_transaction(address, sat, request_id)
+            .create_and_send_transaction(address, sat, fee_rate, request_id)
             .await
             .unwrap();
         let metadata = self

--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -105,8 +105,16 @@ pub async fn assert_issue(
 ) {
     let issue = parachain_rpc.request_issue(amount, vault_id).await.unwrap();
 
+    let fee_rate = 1000;
+
     let metadata = btc_rpc
-        .send_to_address(issue.vault_address, (issue.amount + issue.fee) as u64, None, 0)
+        .send_to_address(
+            issue.vault_address,
+            (issue.amount + issue.fee) as u64,
+            None,
+            fee_rate,
+            0,
+        )
         .await
         .unwrap();
 

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -8,9 +8,10 @@ use futures::{
     try_join, TryStreamExt,
 };
 use runtime::{
-    BtcAddress, BtcRelayPallet, H256Le, InterBtcParachain, InterBtcRedeemRequest, InterBtcRefundRequest,
-    InterBtcReplaceRequest, IssuePallet, PrettyPrint, RedeemPallet, RedeemRequestStatus, RefundPallet, ReplacePallet,
-    ReplaceRequestStatus, RequestRefundEvent, SecurityPallet, UtilFuncs, VaultId, VaultRegistryPallet, H256,
+    BtcAddress, BtcRelayPallet, FixedPointNumber, FixedU128, H256Le, InterBtcParachain, InterBtcRedeemRequest,
+    InterBtcRefundRequest, InterBtcReplaceRequest, IssuePallet, OraclePallet, PrettyPrint, RedeemPallet,
+    RedeemRequestStatus, RefundPallet, ReplacePallet, ReplaceRequestStatus, RequestRefundEvent, SecurityPallet,
+    UtilFuncs, VaultId, VaultRegistryPallet, H256,
 };
 use service::{spawn_cancelable, ShutdownSender};
 use std::{collections::HashMap, convert::TryInto, time::Duration};
@@ -170,6 +171,16 @@ impl Request {
         }
     }
 
+    /// returns the fee rate in sat/vByte
+    async fn get_fee_rate<P: OraclePallet + Send + Sync>(&self, parachain_rpc: &P) -> Result<u64, Error> {
+        let fee_rate: FixedU128 = parachain_rpc.get_bitcoin_fees().await?;
+        Ok(fee_rate
+            .into_inner()
+            .checked_div(FixedU128::accuracy())
+            .ok_or(Error::ArithmeticUnderflow)?
+            .try_into()?)
+    }
+
     /// Makes the bitcoin transfer and executes the request
     pub async fn pay_and_execute<
         B: BitcoinCoreApi + Clone + Send + Sync + 'static,
@@ -179,6 +190,7 @@ impl Request {
             + RedeemPallet
             + SecurityPallet
             + VaultRegistryPallet
+            + OraclePallet
             + UtilFuncs
             + Clone
             + Send
@@ -216,7 +228,7 @@ impl Request {
     )]
     async fn transfer_btc<
         B: BitcoinCoreApi + Clone,
-        P: BtcRelayPallet + VaultRegistryPallet + UtilFuncs + Clone + Send + Sync,
+        P: OraclePallet + BtcRelayPallet + VaultRegistryPallet + UtilFuncs + Clone + Send + Sync,
     >(
         &self,
         parachain_rpc: &P,
@@ -224,8 +236,10 @@ impl Request {
         num_confirmations: u32,
         vault_id: VaultId,
     ) -> Result<TransactionMetadata, Error> {
+        let fee_rate = self.get_fee_rate(parachain_rpc).await?;
+
         let tx = btc_rpc
-            .create_transaction(self.btc_address, self.amount as u64, Some(self.hash))
+            .create_transaction(self.btc_address, self.amount as u64, fee_rate, Some(self.hash))
             .await?;
         let recipient = tx.recipient.clone();
         tracing::info!("Sending bitcoin to {}", recipient);
@@ -545,7 +559,7 @@ mod tests {
     use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
         AccountId, BlockNumber, BtcPublicKey, CurrencyId, Error as RuntimeError, ErrorCode, InterBtcRichBlockHeader,
-        InterBtcVault, StatusCode, Token, DOT, IBTC,
+        InterBtcVault, OracleKey, StatusCode, Token, DOT, IBTC,
     };
     use sp_core::H160;
     use std::collections::BTreeSet;
@@ -641,6 +655,17 @@ mod tests {
             async fn get_error_codes(&self) -> Result<BTreeSet<ErrorCode>, RuntimeError>;
             async fn get_current_active_block_number(&self) -> Result<u32, RuntimeError>;
         }
+
+        #[async_trait]
+        pub trait OraclePallet {
+            async fn get_exchange_rate(&self, currency_id: CurrencyId) -> Result<FixedU128, RuntimeError>;
+            async fn feed_values(&self, values: Vec<(OracleKey, FixedU128)>) -> Result<(), RuntimeError>;
+            async fn set_bitcoin_fees(&self, value: FixedU128) -> Result<(), RuntimeError>;
+            async fn get_bitcoin_fees(&self) -> Result<FixedU128, RuntimeError>;
+            async fn wrapped_to_collateral(&self, amount: u128, currency_id: CurrencyId) -> Result<u128, RuntimeError>;
+            async fn collateral_to_wrapped(&self, amount: u128, currency_id: CurrencyId) -> Result<u128, RuntimeError>;
+            async fn has_updated(&self, key: &OracleKey) -> Result<bool, RuntimeError>;
+        }
     }
 
     impl Clone for MockProvider {
@@ -676,10 +701,10 @@ mod tests {
             async fn get_block_info(&self, hash: &BlockHash) -> Result<GetBlockResult, BitcoinError>;
             async fn get_mempool_transactions<'a>(&'a self) -> Result<Box<dyn Iterator<Item = Result<Transaction, BitcoinError>> + Send + 'a>, BitcoinError>;
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn create_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>) -> Result<LockedTransaction, BitcoinError>;
+            async fn create_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, fee_rate: u64, request_id: Option<H256>) -> Result<LockedTransaction, BitcoinError>;
             async fn send_transaction(&self, transaction: LockedTransaction) -> Result<Txid, BitcoinError>;
-            async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
-            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
+            async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, fee_rate: u64, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
+            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>, fee_rate: u64, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn wallet_has_public_key<P>(&self, public_key: P) -> Result<bool, BitcoinError> where P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
@@ -759,6 +784,10 @@ mod tests {
         ) -> (Request, MockProvider, VaultData<MockBitcoin>) {
             let mut parachain_rpc = MockProvider::default();
             parachain_rpc
+                .expect_get_bitcoin_fees()
+                .returning(move || Ok(FixedU128::from(1000)));
+
+            parachain_rpc
                 .expect_get_current_active_block_number()
                 .returning(move || Ok(current_parachain_height));
             parachain_rpc.expect_execute_redeem().returning(|_, _, _| Ok(()));
@@ -770,18 +799,20 @@ mod tests {
                 .expect_get_block_count()
                 .returning(move || Ok(current_bitcoin_height as u64));
 
-            btc_rpc.expect_create_transaction::<BtcAddress>().returning(|_, _, _| {
-                Ok(LockedTransaction::new(
-                    Transaction {
-                        version: 0,
-                        lock_time: 0,
-                        input: vec![],
-                        output: vec![],
-                    },
-                    Default::default(),
-                    None,
-                ))
-            });
+            btc_rpc
+                .expect_create_transaction::<BtcAddress>()
+                .returning(|_, _, _, _| {
+                    Ok(LockedTransaction::new(
+                        Transaction {
+                            version: 0,
+                            lock_time: 0,
+                            input: vec![],
+                            output: vec![],
+                        },
+                        Default::default(),
+                        None,
+                    ))
+                });
 
             btc_rpc.expect_send_transaction().returning(|_| Ok(Txid::default()));
 
@@ -895,6 +926,9 @@ mod tests {
     async fn should_pay_and_execute_replace() {
         let mut parachain_rpc = MockProvider::default();
         parachain_rpc
+            .expect_get_bitcoin_fees()
+            .returning(move || Ok(FixedU128::from(1000)));
+        parachain_rpc
             .expect_get_current_active_block_number()
             .times(1)
             .returning(|| Ok(50));
@@ -908,18 +942,20 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let mut btc_rpc = MockBitcoin::default();
-        btc_rpc.expect_create_transaction::<BtcAddress>().returning(|_, _, _| {
-            Ok(LockedTransaction::new(
-                Transaction {
-                    version: 0,
-                    lock_time: 0,
-                    input: vec![],
-                    output: vec![],
-                },
-                Default::default(),
-                None,
-            ))
-        });
+        btc_rpc
+            .expect_create_transaction::<BtcAddress>()
+            .returning(|_, _, _, _| {
+                Ok(LockedTransaction::new(
+                    Transaction {
+                        version: 0,
+                        lock_time: 0,
+                        input: vec![],
+                        output: vec![],
+                    },
+                    Default::default(),
+                    None,
+                ))
+            });
 
         btc_rpc.expect_send_transaction().returning(|_| Ok(Txid::default()));
 

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -822,10 +822,10 @@ mod tests {
             async fn get_block_info(&self, hash: &BlockHash) -> Result<GetBlockResult, BitcoinError>;
             async fn get_mempool_transactions<'a>(&'a self) -> Result<Box<dyn Iterator<Item = Result<Transaction, BitcoinError>> + Send + 'a>, BitcoinError>;
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn create_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>) -> Result<LockedTransaction, BitcoinError>;
+            async fn create_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, fee_rate: u64, request_id: Option<H256>) -> Result<LockedTransaction, BitcoinError>;
             async fn send_transaction(&self, transaction: LockedTransaction) -> Result<Txid, BitcoinError>;
-            async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
-            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
+            async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, fee_rate: u64, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
+            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>, fee_rate: u64, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn wallet_has_public_key<P>(&self, public_key: P) -> Result<bool, BitcoinError> where P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -267,6 +267,7 @@ mod tests {
                 &self,
                 address: A,
                 sat: u64,
+                fee_rate: u64,
                 request_id: Option<H256>,
             ) -> Result<LockedTransaction, BitcoinError>;
             async fn send_transaction(&self, transaction: LockedTransaction) -> Result<Txid, BitcoinError>;
@@ -274,6 +275,7 @@ mod tests {
                 &self,
                 address: A,
                 sat: u64,
+                fee_rate: u64,
                 request_id: Option<H256>,
             ) -> Result<Txid, BitcoinError>;
             async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(
@@ -281,6 +283,7 @@ mod tests {
                 address: A,
                 sat: u64,
                 request_id: Option<H256>,
+                fee_rate: u64,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;

--- a/vault/src/vaults.rs
+++ b/vault/src/vaults.rs
@@ -353,6 +353,7 @@ mod tests {
                 &self,
                 address: A,
                 sat: u64,
+                fee_rate: u64,
                 request_id: Option<H256>,
             ) -> Result<LockedTransaction, BitcoinError>;
             async fn send_transaction(&self, transaction: LockedTransaction) -> Result<Txid, BitcoinError>;
@@ -360,6 +361,7 @@ mod tests {
                 &self,
                 address: A,
                 sat: u64,
+                fee_rate: u64,
                 request_id: Option<H256>,
             ) -> Result<Txid, BitcoinError>;
             async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(
@@ -367,6 +369,7 @@ mod tests {
                 address: A,
                 sat: u64,
                 request_id: Option<H256>,
+                fee_rate: u64,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;

--- a/vault/tests/vault_integration_tests.rs
+++ b/vault/tests/vault_integration_tests.rs
@@ -108,7 +108,12 @@ async fn pay_redeem_from_vault_wallet(
                 let request = vault_provider.get_redeem_request(event.redeem_id).await.unwrap();
                 // step 1: create a spending transaction from some arbitrary address
                 let mut transaction = btc_rpc
-                    .create_transaction(request.btc_address, request.amount_btc as u64, Some(event.redeem_id))
+                    .create_transaction(
+                        request.btc_address,
+                        request.amount_btc as u64,
+                        1000,
+                        Some(event.redeem_id),
+                    )
                     .await
                     .unwrap();
                 let mut x = [3; 33];
@@ -216,7 +221,7 @@ async fn test_report_vault_theft_succeeds() {
 
             // step 1: create a spending transaction from some arbitrary address
             let mut transaction = btc_rpc
-                .create_transaction(BtcAddress::P2PKH(H160::from_slice(&[4; 20])), 1500, None)
+                .create_transaction(BtcAddress::P2PKH(H160::from_slice(&[4; 20])), 1500, 1000, None)
                 .await
                 .unwrap();
             // set the hash in the input script. Note: p2wpkh needs to start with 2 or 3
@@ -753,7 +758,13 @@ async fn test_cancellation_succeeds() {
                         for _ in 0u32..2 {
                             assert_ok!(
                                 btc_rpc
-                                    .send_to_address(BtcAddress::P2PKH(H160::from_slice(&[0; 20])), 100_000, None, 1)
+                                    .send_to_address(
+                                        BtcAddress::P2PKH(H160::from_slice(&[0; 20])),
+                                        100_000,
+                                        None,
+                                        1000,
+                                        1
+                                    )
                                     .await
                             );
                         }
@@ -814,6 +825,7 @@ async fn test_refund_succeeds() {
                     issue.vault_address,
                     (issue.amount + issue.fee) as u64 + over_payment,
                     None,
+                    1000,
                     0,
                 )
                 .await
@@ -895,6 +907,7 @@ async fn test_issue_overpayment_succeeds() {
                     issue.vault_address,
                     (issue.amount + issue.fee) as u64 * over_payment_factor as u64,
                     None,
+                    1000,
                     0,
                 )
                 .await
@@ -968,7 +981,7 @@ async fn test_automatic_issue_execution_succeeds() {
 
             assert_ok!(
                 btc_rpc
-                    .send_to_address(issue.vault_address, (issue.amount + issue.fee) as u64, None, 0)
+                    .send_to_address(issue.vault_address, (issue.amount + issue.fee) as u64, None, 1000, 0)
                     .await
             );
 
@@ -1042,7 +1055,13 @@ async fn test_automatic_issue_execution_succeeds_with_big_transaction() {
 
             assert_ok!(
                 btc_rpc
-                    .send_to_address_with_many_outputs(issue.vault_address, (issue.amount + issue.fee) as u64, None, 0)
+                    .send_to_address_with_many_outputs(
+                        issue.vault_address,
+                        (issue.amount + issue.fee) as u64,
+                        None,
+                        1000,
+                        0
+                    )
                     .await
             );
 
@@ -1114,12 +1133,12 @@ async fn test_execute_open_requests_succeeds() {
         // send btc for redeem 0
         assert_ok!(
             btc_rpc
-                .send_to_address(address, redeems[0].amount_btc as u64, Some(redeem_ids[0]), 0)
+                .send_to_address(address, redeems[0].amount_btc as u64, Some(redeem_ids[0]), 1000, 0)
                 .await
         );
 
         let transaction = btc_rpc
-            .create_transaction(address, redeems[1].amount_btc as u64, Some(redeem_ids[1]))
+            .create_transaction(address, redeems[1].amount_btc as u64, 1000, Some(redeem_ids[1]))
             .await
             .unwrap()
             .transaction;


### PR DESCRIPTION
With the PR, clients rely on the oracle for fee estimation rather than their local bitcoin node. This should prevent issues with bitcoin occasionally using the fallback fee.