### PR TITLE
fix: fundrawtransaction: opt-in to rbf & correct fee rate

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -749,8 +749,11 @@ impl BitcoinCoreApi for BitcoinCore {
             // transaction to the bitcoind. If we don't do this, the same uxto may be used
             // as input twice (i.e. double spend)
             let lock = self.transaction_creation_lock.clone().lock_owned().await;
+            // FundRawTransactionOptions takes an amount per kvByte, rather than per vByte
+            let fee_rate = fee_rate.saturating_mul(1_000);
             let funding_opts = FundRawTransactionOptions {
                 fee_rate: Some(Amount::from_sat(fee_rate)),
+                replaceable: Some(true),
                 ..Default::default()
             };
 


### PR DESCRIPTION
Two fixes:

- fee-rate: the rpc [supports](https://developer.bitcoin.org/reference/rpc/fundrawtransaction.html) two different units for the fee rate: if you use `feeRate` in camelCase, it is interpreted as `BTC/kvB`. If you use `fee_rate` in snake_case, it is interpreted as `sat/vB`. The one used by our rpc library is the camelCase one, because of [this rename](https://github.com/rust-bitcoin/rust-bitcoincore-rpc/blob/657eebd0dd24c19b7d145b49144f480f5dc09ec3/json/src/lib.rs#L1773)
- We opted in into rbf in `createrawtransaction`. However, we didn't specify inputs as we only add these later in `fundrawtransaction`. Since a transaction is marked for rbf by modifying the sequence number _on the inputs_, setting rbf on `createrawtransaction` effectively was a noop. As a solution, we now opt-in at `fundrawtransaction` 