### PR TITLE
feat: allow oracle to use a combination of fixed and real exchange rates

### DIFF
--- a/oracle/src/error.rs
+++ b/oracle/src/error.rs
@@ -15,9 +15,7 @@ pub enum Error {
     InvalidExchangeRate,
     #[error("Invalid fee estimate")]
     InvalidFeeEstimate,
-    #[error(
-        "Invalid arguments. Either provide as many exchange rates as currencies, or provide none and a coingecko url"
-    )]
+    #[error("Invalid arguments. Either provide explicit exchange rates (e.g. KSM=1) or provide a coingecko url")]
     InvalidArguments,
 
     #[error("ReqwestError: {0}")]


### PR DESCRIPTION
Will be required on interlay. Before, we required either all or none exchange rates to be fixed. Now it is possible to mix both options.

Usage is e.g. `--coingecko=https://api.coingecko.com/api/v3/ --currency-id INTR=6649 --currency-id DOT` 