### PR TITLE
fix: allow foreign assets to be used as cli argument in vault and oracle

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -5,12 +5,11 @@ use codec::Error as CodecError;
 use jsonrpsee::{client_transport::ws::WsHandshakeError, core::error::Error as RequestError, types::error::CallError};
 use prometheus::Error as PrometheusError;
 use serde_json::Error as SerdeJsonError;
-use std::{array::TryFromSliceError, fmt::Debug, io::Error as IoError, num::TryFromIntError};
+use std::{array::TryFromSliceError, fmt::Debug, io::Error as IoError, num::TryFromIntError, str::Utf8Error};
 use subxt::{sp_core::crypto::SecretStringError, BasicError, ModuleError, TransactionError};
 use thiserror::Error;
 use tokio::time::error::Elapsed;
 use url::ParseError as UrlParseError;
-
 pub type SubxtError = subxt::Error<DispatchError>;
 
 #[derive(Error, Debug)]
@@ -25,6 +24,8 @@ pub enum Error {
     RequestReplaceIDNotFound,
     #[error("Could not get block")]
     BlockNotFound,
+    #[error("Could not get foreign asset")]
+    AssetNotFound,
     #[error("Could not get vault")]
     VaultNotFound,
     #[error("Vault has been liquidated")]
@@ -81,6 +82,8 @@ pub enum Error {
     UrlParseError(#[from] UrlParseError),
     #[error("PrometheusError: {0}")]
     PrometheusError(#[from] PrometheusError),
+    #[error("Utf8Error: {0}")]
+    Utf8Error(#[from] Utf8Error),
 }
 
 impl From<BasicError> for Error {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,7 +9,7 @@ mod rpc;
 
 pub mod types;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "standalone-metadata"))]
 mod tests;
 
 #[cfg(all(feature = "testing-utils", feature = "standalone-metadata"))]

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -13,10 +13,10 @@ use crate::{
 ))]
 use crate::{BTC_RELAY_MODULE, STABLE_BITCOIN_CONFIRMATIONS, STABLE_PARACHAIN_CONFIRMATIONS};
 use async_trait::async_trait;
-use codec::Encode;
+use codec::{Decode, Encode};
 use futures::{future::join_all, stream::StreamExt, FutureExt, SinkExt};
 use module_oracle_rpc_runtime_api::BalanceWrapper;
-use primitives::UnsignedFixedPoint;
+use primitives::{CurrencyInfo, UnsignedFixedPoint};
 use serde_json::Value;
 use sp_runtime::FixedPointNumber;
 use std::{collections::BTreeSet, future::Future, ops::RangeInclusive, sync::Arc, time::Duration};
@@ -411,6 +411,70 @@ impl InterBtcParachain {
             .unwrap_err()
             .into()
     }
+
+    #[cfg(all(test, feature = "standalone-metadata"))]
+    pub async fn register_dummy_assets(&self) -> Result<(), Error> {
+        self.with_unique_signer(|signer| async move {
+            let metadatas = ["ABC", "TEst", "QQQ"].map(|symbol| GenericAssetMetadata {
+                decimals: 10,
+                location: None,
+                name: b"irrelevant".to_vec(),
+                symbol: symbol.as_bytes().to_vec(),
+                existential_deposit: 0,
+                additional: metadata::runtime_types::interbtc_primitives::CustomMetadata { fee_per_second: 0 },
+            });
+
+            let registration_calls = metadatas
+                .map(|metadata| {
+                    EncodedCall::AssetRegistry(
+                        metadata::runtime_types::orml_asset_registry::module::Call::register_asset {
+                            metadata: metadata.clone(),
+                            asset_id: None,
+                        },
+                    )
+                })
+                .to_vec();
+
+            let batch = EncodedCall::Utility(metadata::runtime_types::pallet_utility::pallet::Call::batch {
+                calls: registration_calls,
+            });
+
+            self.api
+                .tx()
+                .sudo()
+                .sudo(batch)
+                .sign_and_submit_then_watch_default(&signer)
+                .await
+        })
+        .await?;
+        Ok(())
+    }
+
+    pub async fn parse_currency_id(&self, symbol: String) -> Result<CurrencyId, Error> {
+        let uppercase_symbol = symbol.to_uppercase();
+        // try hardcoded currencies first
+        match uppercase_symbol.as_str() {
+            id if id == DOT.symbol() => Ok(Token(DOT)),
+            id if id == IBTC.symbol() => Ok(Token(IBTC)),
+            id if id == INTR.symbol() => Ok(Token(INTR)),
+            id if id == KSM.symbol() => Ok(Token(KSM)),
+            id if id == KBTC.symbol() => Ok(Token(KBTC)),
+            id if id == KINT.symbol() => Ok(Token(KINT)),
+            _ => self
+                .get_foreign_assets_metadata()
+                .await?
+                .into_iter()
+                .find_map(|(key, value)| {
+                    let asset_symbol = std::str::from_utf8(&value.symbol).ok()?.to_uppercase();
+                    if asset_symbol == uppercase_symbol {
+                        Some(Ok(CurrencyId::ForeignAsset(key)))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(Err(Error::InvalidCurrency)),
+        }
+    }
 }
 
 #[async_trait]
@@ -427,6 +491,8 @@ pub trait UtilFuncs {
     fn get_account_id(&self) -> &AccountId;
 
     fn is_this_vault(&self, vault_id: &VaultId) -> bool;
+
+    async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, Error>;
 }
 
 #[async_trait]
@@ -450,6 +516,23 @@ impl UtilFuncs for InterBtcParachain {
 
     fn is_this_vault(&self, vault_id: &VaultId) -> bool {
         &vault_id.account_id == self.get_account_id()
+    }
+
+    async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, Error> {
+        let head = self.get_latest_block_hash().await?;
+
+        let mut ret = Vec::new();
+        let mut metadata_iter = self.api.storage().asset_registry().metadata_iter(head).await?;
+        while let Some((key, value)) = metadata_iter.next().await? {
+            let raw_key = key.0.clone();
+
+            // last bytes are the raw key
+            let mut key = &raw_key[raw_key.len() - 4..];
+
+            let decoded_key: u32 = Decode::decode(&mut key)?;
+            ret.push((decoded_key, value));
+        }
+        Ok(ret)
     }
 }
 

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -5,7 +5,7 @@ use subxt::sp_core::{crypto::Ss58Codec, sr25519::Pair as KeyPair};
 pub use primitives::{
     CurrencyId,
     CurrencyId::{ForeignAsset, Token},
-    TokenSymbol::{DOT, IBTC, INTR, KBTC, KINT, KSM},
+    TokenSymbol::{self, DOT, IBTC, INTR, KBTC, KINT, KSM},
 };
 
 pub use currency_id::CurrencyIdExt;

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -74,6 +74,12 @@ mod metadata_aliases {
     pub use metadata::tokens::events::Endowed as EndowedEvent;
 
     pub use metadata::runtime_types::{
+        interbtc_primitives::CustomMetadata as InterBtcAdditionalMetadata,
+        orml_traits::asset_registry::AssetMetadata as GenericAssetMetadata,
+    };
+    pub type AssetMetadata = GenericAssetMetadata<Balance, InterBtcAdditionalMetadata>;
+
+    pub use metadata::runtime_types::{
         btc_relay::pallet::Error as BtcRelayPalletError, frame_system::pallet::Error as SystemPalletError,
         issue::pallet::Error as IssuePalletError, redeem::pallet::Error as RedeemPalletError,
         relay::pallet::Error as RelayPalletError, security::pallet::Error as SecurityPalletError,

--- a/vault/src/cancellation.rs
+++ b/vault/src/cancellation.rs
@@ -320,8 +320,8 @@ mod tests {
     use futures::channel::mpsc;
     use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
-        AccountId, BtcAddress, BtcPublicKey, CurrencyId, ErrorCode, InterBtcIssueRequest, InterBtcReplaceRequest,
-        IssueRequestStatus, RequestIssueEvent, StatusCode, Token, VaultId, DOT, IBTC,
+        AccountId, AssetMetadata, BtcAddress, BtcPublicKey, CurrencyId, ErrorCode, InterBtcIssueRequest,
+        InterBtcReplaceRequest, IssueRequestStatus, RequestIssueEvent, StatusCode, Token, VaultId, DOT, IBTC,
     };
     use std::collections::BTreeSet;
 
@@ -371,6 +371,7 @@ mod tests {
             fn get_native_currency_id(&self) -> CurrencyId;
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;
+            async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, RuntimeError>;
         }
 
         #[async_trait]

--- a/vault/src/cancellation.rs
+++ b/vault/src/cancellation.rs
@@ -372,6 +372,7 @@ mod tests {
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;
             async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, RuntimeError>;
+            async fn get_foreign_asset_metadata(&self, id: u32) -> Result<AssetMetadata, RuntimeError>;
         }
 
         #[async_trait]

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -588,6 +588,7 @@ mod tests {
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;
             async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, RuntimeError>;
+            async fn get_foreign_asset_metadata(&self, id: u32) -> Result<AssetMetadata, RuntimeError>;
         }
         #[async_trait]
         pub trait VaultRegistryPallet {

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -558,8 +558,8 @@ mod tests {
     };
     use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
-        AccountId, BlockNumber, BtcPublicKey, CurrencyId, Error as RuntimeError, ErrorCode, InterBtcRichBlockHeader,
-        InterBtcVault, OracleKey, StatusCode, Token, DOT, IBTC,
+        AccountId, AssetMetadata, BlockNumber, BtcPublicKey, CurrencyId, Error as RuntimeError, ErrorCode,
+        InterBtcRichBlockHeader, InterBtcVault, OracleKey, StatusCode, Token, DOT, IBTC,
     };
     use sp_core::H160;
     use std::collections::BTreeSet;
@@ -587,6 +587,7 @@ mod tests {
             fn get_native_currency_id(&self) -> CurrencyId;
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;
+            async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, RuntimeError>;
         }
         #[async_trait]
         pub trait VaultRegistryPallet {

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -712,9 +712,9 @@ mod tests {
     };
     use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
-        AccountId, Balance, BlockNumber, BtcAddress, BtcPublicKey, CurrencyId, Error as RuntimeError, ErrorCode,
-        InterBtcIssueRequest, InterBtcRedeemRequest, InterBtcRefundRequest, InterBtcReplaceRequest, InterBtcVault,
-        RequestIssueEvent, StatusCode, Token, VaultId, VaultStatus, Wallet, DOT, H256, IBTC, INTR,
+        AccountId, AssetMetadata, Balance, BlockNumber, BtcAddress, BtcPublicKey, CurrencyId, Error as RuntimeError,
+        ErrorCode, InterBtcIssueRequest, InterBtcRedeemRequest, InterBtcRefundRequest, InterBtcReplaceRequest,
+        InterBtcVault, RequestIssueEvent, StatusCode, Token, VaultId, VaultStatus, Wallet, DOT, H256, IBTC, INTR,
     };
     use std::collections::BTreeSet;
 
@@ -728,6 +728,7 @@ mod tests {
             fn get_native_currency_id(&self) -> CurrencyId;
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;
+            async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, RuntimeError>;
         }
 
         #[async_trait]

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -729,6 +729,7 @@ mod tests {
             fn get_account_id(&self) -> &AccountId;
             fn is_this_vault(&self, vault_id: &VaultId) -> bool;
             async fn get_foreign_assets_metadata(&self) -> Result<Vec<(u32, AssetMetadata)>, RuntimeError>;
+            async fn get_foreign_asset_metadata(&self, id: u32) -> Result<AssetMetadata, RuntimeError>;
         }
 
         #[async_trait]

--- a/vault/src/relay/mod.rs
+++ b/vault/src/relay/mod.rs
@@ -4,7 +4,7 @@ use service::Error as ServiceError;
 use std::{fmt::Debug, time::Duration};
 use tokio::time::sleep;
 
-use crate::vaults::{RandomDelay, ZeroDelay};
+use crate::vaults::RandomDelay;
 
 mod backing;
 mod error;
@@ -201,7 +201,7 @@ pub async fn run_relayer<RD: RandomDelay + Debug + Send + Sync + Clone>(
 
 #[cfg(test)]
 mod tests {
-    use crate::vaults::RandomDelay;
+    use crate::vaults::{RandomDelay, ZeroDelay};
 
     use super::*;
     use async_trait::async_trait;


### PR DESCRIPTION
This allows vaults and oracles to use foreign asset symbols in addition to the hardcoded ones. Since we need to connect to the parachain to be able to determine the parachain id, I had to change the type in the arguments to strings, and only parse them after connecting. Tested on testnet in addition to the integration test