### PR TITLE
feat(pruned-client): implementation of pruned bitcoin node support in the vault, with electrs querying for issue requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "num-traits",
  "rand 0.7.3",
  "regex",
+ "reqwest",
  "serde_json",
  "sp-core",
  "thiserror",
@@ -1787,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "esplora-btc-api"
-version = "1.0.5"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccc663368a097acaef02957f728141fe5c1a2932073e50044a3b0cea01c7abb"
+checksum = "f0309de257f421df7081bfb9d5c3167adbd2c23c3589e0b6c5a2cdbdb826be65"
 dependencies = [
  "reqwest",
  "serde",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0.71"
 log = "0.4.0"
 hyper = "0.10"
 esplora-btc-api = "1.0.3"
+reqwest = "0.11.11"
 
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }

--- a/bitcoin/src/electrs.rs
+++ b/bitcoin/src/electrs.rs
@@ -1,4 +1,7 @@
 use crate::Error;
+use esplora_btc_api::models::Transaction;
+
+const ELECTRS_TRANSACTIONS_PER_PAGE: usize = 25;
 
 async fn get(base_path: &str, url: &str) -> Result<String, Error> {
     let response = reqwest::get(format!("{}/{}", base_path, url)).await?;
@@ -10,10 +13,29 @@ async fn get(base_path: &str, url: &str) -> Result<String, Error> {
     }
 }
 
+// the esplora_btc_api lib breaks on these two because it tries to serde_json::from_str on a plain string value
 pub async fn get_tx_hex(base_path: &str, tx_id: &str) -> Result<String, Error> {
     get(base_path, &format!("tx/{}/hex", tx_id)).await
 }
 
 pub async fn get_tx_merkle_block_proof(base_path: &str, tx_id: &str) -> Result<String, Error> {
     get(base_path, &format!("tx/{}/merkleblock-proof", tx_id)).await
+}
+
+// and it doesn't currently support the paged api call
+pub async fn get_address_tx_history_full(base_path: &str, address: &str) -> Result<Vec<Transaction>, Error> {
+    let mut last_seen_txid = "".to_owned();
+    let mut ret = Vec::<Transaction>::default();
+    loop {
+        let mut transactions: Vec<Transaction> =
+            serde_json::from_str(&get(base_path, &format!("address/{}/txs/chain/{}", address, last_seen_txid)).await?)?;
+        let page_size = transactions.len();
+        last_seen_txid = transactions.last().map_or("", |tx| &tx.txid).to_owned();
+        ret.append(&mut transactions);
+        if page_size < ELECTRS_TRANSACTIONS_PER_PAGE {
+            // no further pages
+            break;
+        }
+    }
+    Ok(ret)
 }

--- a/bitcoin/src/electrs.rs
+++ b/bitcoin/src/electrs.rs
@@ -1,0 +1,19 @@
+use crate::Error;
+
+async fn get(base_path: &str, url: &str) -> Result<String, Error> {
+    let response = reqwest::get(format!("{}/{}", base_path, url)).await?;
+    let status = response.status();
+    if status.is_client_error() || status.is_server_error() {
+        Err(Error::ElectrsQueryFailed)
+    } else {
+        Ok(response.text().await?)
+    }
+}
+
+pub async fn get_tx_hex(base_path: &str, tx_id: &str) -> Result<String, Error> {
+    get(base_path, &format!("tx/{}/hex", tx_id)).await
+}
+
+pub async fn get_tx_merkle_block_proof(base_path: &str, tx_id: &str) -> Result<String, Error> {
+    get(base_path, &format!("tx/{}/merkleblock-proof", tx_id)).await
+}

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -17,8 +17,8 @@ type ElectrsTxByScriptHashError =
     esplora_btc_api::apis::Error<esplora_btc_api::apis::scripthash_api::GetTxsByScripthashError>;
 type ElectrsAddressTxHistoryError =
     esplora_btc_api::apis::Error<esplora_btc_api::apis::address_api::GetAddressTxHistoryError>;
-type ElectrsRawTxError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxRawError>;
-type ElectrsMerkleProofError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxMerkleProofError>;
+type ElectrsRawTxError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxHexError>;
+type ElectrsMerkleProofError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxMerkleBlockProofError>;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -9,6 +9,7 @@ use bitcoincore_rpc::{
     jsonrpc::{error::RpcError, Error as JsonRpcError},
 };
 use hex::FromHexError;
+use reqwest::Error as ReqwestError;
 use serde_json::Error as SerdeJsonError;
 use thiserror::Error;
 use tokio::time::error::Elapsed;
@@ -17,8 +18,6 @@ type ElectrsTxByScriptHashError =
     esplora_btc_api::apis::Error<esplora_btc_api::apis::scripthash_api::GetTxsByScripthashError>;
 type ElectrsAddressTxHistoryError =
     esplora_btc_api::apis::Error<esplora_btc_api::apis::address_api::GetAddressTxHistoryError>;
-type ElectrsRawTxError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxHexError>;
-type ElectrsMerkleProofError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxMerkleBlockProofError>;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -43,9 +42,7 @@ pub enum Error {
     #[error("ElectrsError: {0}")]
     ElectrsAddressTxHistoryError(#[from] ElectrsAddressTxHistoryError),
     #[error("ElectrsError: {0}")]
-    ElectrsRawTxError(#[from] ElectrsRawTxError),
-    #[error("ElectrsError: {0}")]
-    ElectrsMerkleProofError(#[from] ElectrsMerkleProofError),
+    ReqwestError(#[from] ReqwestError),
     #[error("Connected to incompatable bitcoin core version: {0}")]
     IncompatibleVersion(usize),
 
@@ -65,6 +62,8 @@ pub enum Error {
     WalletNotFound,
     #[error("Invalid Bitcoin network")]
     InvalidBitcoinNetwork,
+    #[error("Unable to query Electrs for transaction data")]
+    ElectrsQueryFailed,
 }
 
 impl Error {

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -13,7 +13,12 @@ use serde_json::Error as SerdeJsonError;
 use thiserror::Error;
 use tokio::time::error::Elapsed;
 
-pub type ElectrsError = esplora_btc_api::apis::Error<esplora_btc_api::apis::scripthash_api::GetTxsByScripthashError>;
+type ElectrsTxByScriptHashError =
+    esplora_btc_api::apis::Error<esplora_btc_api::apis::scripthash_api::GetTxsByScripthashError>;
+type ElectrsAddressTxHistoryError =
+    esplora_btc_api::apis::Error<esplora_btc_api::apis::address_api::GetAddressTxHistoryError>;
+type ElectrsRawTxError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxRawError>;
+type ElectrsMerkleProofError = esplora_btc_api::apis::Error<esplora_btc_api::apis::tx_api::GetTxMerkleProofError>;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -34,7 +39,13 @@ pub enum Error {
     #[error("Timeout: {0}")]
     TimeElapsed(#[from] Elapsed),
     #[error("ElectrsError: {0}")]
-    ElectrsError(#[from] ElectrsError),
+    ElectrsTxByScriptHashError(#[from] ElectrsTxByScriptHashError),
+    #[error("ElectrsError: {0}")]
+    ElectrsAddressTxHistoryError(#[from] ElectrsAddressTxHistoryError),
+    #[error("ElectrsError: {0}")]
+    ElectrsRawTxError(#[from] ElectrsRawTxError),
+    #[error("ElectrsError: {0}")]
+    ElectrsMerkleProofError(#[from] ElectrsMerkleProofError),
     #[error("Connected to incompatable bitcoin core version: {0}")]
     IncompatibleVersion(usize),
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -28,7 +28,7 @@ pub use bitcoincore_rpc::{
     jsonrpc::{error::RpcError, Error as JsonRpcError},
     Auth, Client, Error as BitcoinError, RpcApi,
 };
-use electrs::{get_tx_hex, get_tx_merkle_block_proof};
+use electrs::{get_address_tx_history_full, get_tx_hex, get_tx_merkle_block_proof};
 pub use error::{BitcoinRpcError, ConversionError, Error};
 use esplora_btc_api::apis::configuration::Configuration as ElectrsConfiguration;
 pub use iter::{reverse_stream_transactions, stream_blocks, stream_in_chain_transactions};
@@ -899,8 +899,7 @@ impl BitcoinCoreApi for BitcoinCore {
     ) -> Result<(), Error> {
         for address in addresses.into_iter() {
             let address = address.encode_str(self.network)?;
-            let all_transactions =
-                esplora_btc_api::apis::address_api::get_address_tx_history(&self.electrs_config, &address).await?;
+            let all_transactions = get_address_tx_history_full(&self.electrs_config.base_path, &address).await?;
             // filter to only import
             // a) payments in the blockchain (not in mempool), and
             // b) payments TO the address (as bitcoin core will already know about transactions spending FROM it)

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -901,6 +901,9 @@ impl BitcoinCoreApi for BitcoinCore {
             let address = address.encode_str(self.network)?;
             let all_transactions =
                 esplora_btc_api::apis::address_api::get_address_tx_history(&self.electrs_config, &address).await?;
+            // filter to only import a) payments in the blockchain (the API returns mempool transactions
+            // too) and b) payments TO the address (the API also returns any txes that have that
+            // address in the vin, which we will already have since we will have made the payment)
             let confirmed_payments_to = all_transactions.into_iter().filter(|tx| {
                 if let Some(status) = &tx.status {
                     if !status.confirmed {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -902,9 +902,13 @@ impl BitcoinCoreApi for BitcoinCore {
             )
             .await?;
             for transaction in transactions.into_iter() {
-                let rawtx = esplora_btc_api::apis::tx_api::get_tx_raw(&self.electrs_config, &transaction.txid).await?;
+                trace!("Importing pruned transaction {}...", &transaction.txid);
+                let rawtx = esplora_btc_api::apis::tx_api::get_tx_hex(&self.electrs_config, &transaction.txid).await?;
+                trace!("Got rawtx data {}", rawtx);
                 let merkle_proof =
-                    esplora_btc_api::apis::tx_api::get_tx_merkle_proof(&self.electrs_config, &transaction.txid).await?;
+                    esplora_btc_api::apis::tx_api::get_tx_merkle_block_proof(&self.electrs_config, &transaction.txid)
+                        .await?;
+                trace!("Got merkle proof {}", merkle_proof);
                 self.rpc.call(
                     "importprunedfunds",
                     &[serde_json::to_value(rawtx)?, serde_json::to_value(merkle_proof)?],

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 use bitcoin::{
     json,
     secp256k1::{constants::SECRET_KEY_SIZE, PublicKey, Secp256k1, SecretKey},
-    serialize, Amount, BitcoinCoreApi, Block, BlockHash, BlockHeader, Error as BitcoinError, GetBlockResult, Hash,
-    LockedTransaction, Network, OutPoint, PartialAddress, PartialMerkleTree, PrivateKey, Script, Transaction,
+    serialize, Address, Amount, BitcoinCoreApi, Block, BlockHash, BlockHeader, Error as BitcoinError, GetBlockResult,
+    Hash, LockedTransaction, Network, OutPoint, PartialAddress, PartialMerkleTree, PrivateKey, Script, Transaction,
     TransactionExt, TransactionMetadata, TxIn, TxOut, Txid, Uint256, PUBLIC_KEY_SIZE,
 };
 use rand::{thread_rng, Rng};
@@ -381,6 +381,9 @@ impl BitcoinCoreApi for MockBitcoinCore {
         let blocks = self.blocks.read().await;
         Ok(blocks[blocks.len() - 1].block_hash())
     }
+    async fn get_pruned_height(&self) -> Result<u64, BitcoinError> {
+        Ok(0)
+    }
     async fn get_block(&self, hash: &BlockHash) -> Result<Block, BitcoinError> {
         let blocks = self.blocks.read().await;
         let block = blocks
@@ -533,6 +536,13 @@ impl BitcoinCoreApi for MockBitcoinCore {
         Ok(())
     }
     async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError> {
+        Ok(())
+    }
+
+    async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync>(
+        &self,
+        addresses: Vec<A>,
+    ) -> Result<(), BitcoinError> {
         Ok(())
     }
     async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError> {

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -410,8 +410,7 @@ pub async fn execute_open_requests<B: BitcoinCoreApi + Clone + Send + Sync + 'st
 
     // iterate through transactions in reverse order, starting from those in the mempool, and
     // gracefully fail on encountering a pruned blockchain
-    let mut transaction_stream =
-        bitcoin::reverse_stream_transactions(&read_only_btc_rpc, btc_start_height, true).await?;
+    let mut transaction_stream = bitcoin::reverse_stream_transactions(&read_only_btc_rpc, btc_start_height).await?;
     while let Some(result) = transaction_stream.next().await {
         let tx = match result {
             Ok(x) => x,

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -118,11 +118,11 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
     }
 
     // also check in electrs in case there were any requests from before the pruned height
-    if btc_start_height < rescan_start_height {
+    if btc_start_height < btc_pruned_start_height {
         tracing::info!(
             "Also checking electrs for isssue requests between {} and {}...",
             btc_start_height,
-            rescan_start_height
+            btc_pruned_start_height
         );
         bitcoin_core
             .rescan_electrs_for_addresses(

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -96,8 +96,6 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
         if let Err(e) = add_new_deposit_key(bitcoin_core, issue_id, request.btc_public_key).await {
             tracing::error!("Failed to add deposit key #{}: {}", issue_id, e.to_string());
         }
-        // TODO: get TXs from elects
-        // then importprunedfunds
     }
 
     // read height only _after_ the last add_new_deposit_height.If a new block arrives
@@ -120,7 +118,7 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
     // also check in electrs in case there were any requests from before the pruned height
     if btc_start_height < btc_pruned_start_height {
         tracing::info!(
-            "Also checking electrs for isssue requests between {} and {}...",
+            "Also checking electrs for issue requests between {} and {}...",
             btc_start_height,
             btc_pruned_start_height
         );

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -830,6 +830,7 @@ mod tests {
             async fn get_transaction(&self, txid: &Txid, block_hash: Option<BlockHash>) -> Result<Transaction, BitcoinError>;
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, BitcoinError>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
+            async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
             async fn is_block_known(&self, block_hash: BlockHash) -> Result<bool, BitcoinError>;
             async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, BitcoinError>;
             async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, BitcoinError>;
@@ -850,6 +851,7 @@ mod tests {
             async fn wallet_has_public_key<P>(&self, public_key: P) -> Result<bool, BitcoinError> where P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
+            async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync + 'static>(&self, addresses: Vec<A>) -> Result<(), BitcoinError>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
         }

--- a/vault/src/relay/mod.rs
+++ b/vault/src/relay/mod.rs
@@ -4,7 +4,7 @@ use service::Error as ServiceError;
 use std::{fmt::Debug, time::Duration};
 use tokio::time::sleep;
 
-use crate::vaults::{RandomDelay, ZeroDelay};
+use crate::vaults::RandomDelay;
 
 mod backing;
 mod error;
@@ -201,7 +201,7 @@ pub async fn run_relayer<RD: RandomDelay + Debug + Send + Sync + Clone>(
 
 #[cfg(test)]
 mod tests {
-    use crate::vaults::RandomDelay;
+    use crate::vaults::{RandomDelay, ZeroDelay};
 
     use super::*;
     use async_trait::async_trait;

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -241,6 +241,7 @@ mod tests {
             async fn get_transaction(&self, txid: &Txid, block_hash: Option<BlockHash>) -> Result<Transaction, BitcoinError>;
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, BitcoinError>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
+            async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
             async fn is_block_known(&self, block_hash: BlockHash) -> Result<bool, BitcoinError>;
             async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, BitcoinError>;
             async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, BitcoinError>;
@@ -292,6 +293,7 @@ mod tests {
                     P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
+            async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync + 'static>(&self, addresses: Vec<A>) -> Result<(), BitcoinError>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
         }

--- a/vault/src/vaults.rs
+++ b/vault/src/vaults.rs
@@ -446,6 +446,7 @@ mod tests {
             async fn get_transaction(&self, txid: &Txid, block_hash: Option<BlockHash>) -> Result<Transaction, BitcoinError>;
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, BitcoinError>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
+            async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
             async fn is_block_known(&self, block_hash: BlockHash) -> Result<bool, BitcoinError>;
             async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, BitcoinError>;
             async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, BitcoinError>;
@@ -497,6 +498,7 @@ mod tests {
                     P: Into<[u8; PUBLIC_KEY_SIZE]> + From<[u8; PUBLIC_KEY_SIZE]> + Clone + PartialEq + Send + Sync + 'static;
             async fn import_private_key(&self, privkey: PrivateKey) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
+            async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync + 'static>(&self, addresses: Vec<A>) -> Result<(), BitcoinError>;
             async fn find_duplicate_payments(&self, transaction: &Transaction) -> Result<Vec<(Txid, BlockHash)>, BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
         }


### PR DESCRIPTION
As per title.

Outstanding question is integration testing. Bitcoin refuses to prune blocks for a very long time - even when issuing a manual `pruneblockchain` rpc call. It doesn't seem realistically possible to create a situation with a pruned transaction during a test run - not without either forking bitcoin-core to see if this behaviour can be patched for more aggressive pruning, or investigating if manually deleting block data may work. A "normal" integration test for the vault would just mock bitcoin-core to return "success" which seems totally useless given that the critical functionality is specifically importing the tx into the bitcoin wallet, hence this PR currently has no tests. I'm open to discussion on this.