### PR TITLE
Vaultvisor: Vault Auto-Updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ keyfile.json
 .deploy/monitoring/data
 .deploy/monitoring/prometheus
 .deploy/monitoring/alertmanager
+args.txt
+vault-standalone-metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,12 +85,12 @@ dependencies = [
 [[package]]
 name = "annuity"
 version = "1.0.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -98,7 +98,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ version = "1.1.0"
 dependencies = [
  "async-trait",
  "backoff",
- "bitcoin 1.2.0",
+ "bitcoin 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
  "bitcoincore-rpc",
  "clap",
  "esplora-btc-api",
@@ -506,6 +506,25 @@ dependencies = [
 [[package]]
 name = "bitcoin"
 version = "1.2.0"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
+dependencies = [
+ "bitcoin_hashes 0.7.6",
+ "frame-support",
+ "hex",
+ "impl-serde",
+ "parity-scale-codec",
+ "scale-info",
+ "secp256k1 0.20.1",
+ "serde",
+ "sha2 0.8.2",
+ "sp-core",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
+ "spin 0.7.1",
+]
+
+[[package]]
+name = "bitcoin"
+version = "1.2.0"
 source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
 dependencies = [
  "bitcoin_hashes 0.7.6",
@@ -518,7 +537,7 @@ dependencies = [
  "serde",
  "sha2 0.8.2",
  "sp-core",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "spin 0.7.1",
 ]
 
@@ -715,21 +734,41 @@ checksum = "bd769563b4ea2953e2825c9e6b7470a5f55f67e0be00030bf3e390a2a6071f64"
 [[package]]
 name = "btc-relay"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
+]
+
+[[package]]
+name = "btc-relay"
+version = "1.2.0"
+source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+dependencies = [
+ "bitcoin 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "security 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -1289,11 +1328,11 @@ dependencies = [
 [[package]]
 name = "currency"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "mocktopus",
  "orml-tokens",
  "orml-traits",
@@ -1302,7 +1341,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -1408,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "democracy"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1419,7 +1458,7 @@ dependencies = [
  "sp-api",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -1768,12 +1807,12 @@ dependencies = [
 [[package]]
 name = "escrow"
 version = "1.0.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "reward",
  "scale-info",
@@ -1782,7 +1821,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -1870,23 +1909,23 @@ dependencies = [
 [[package]]
 name = "fee"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "currency",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "reward",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "staking",
 ]
 
@@ -2027,7 +2066,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-storage",
 ]
 
@@ -2093,7 +2132,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-tracing",
 ]
 
@@ -2134,7 +2173,7 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-tracing",
  "tt-call",
 ]
@@ -2186,7 +2225,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-version",
 ]
 
@@ -2348,6 +2387,10 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -2483,6 +2526,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-net"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351e6f94c76579cc9f9323a15f209086fc7bd428bff4288723d3a417851757b2"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "js-sys",
+ "pin-project 1.0.10",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2555,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "929c53c913bb7a88d75d9dc3e9705f963d8c2b9001510b25ddaf671b9fb7049d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2931,26 +3005,42 @@ dependencies = [
 [[package]]
 name = "interbtc-primitives"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "bstringify",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
+ "xcm",
+]
+
+[[package]]
+name = "interbtc-primitives"
+version = "1.2.0"
+source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+dependencies = [
+ "bitcoin 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
+ "bstringify",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "xcm",
 ]
 
 [[package]]
 name = "interbtc-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "futures 0.3.21",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "jsonrpsee 0.13.1",
  "module-btc-relay-rpc",
  "module-issue-rpc",
@@ -2977,10 +3067,10 @@ dependencies = [
 [[package]]
 name = "interbtc-runtime-standalone"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "annuity",
- "btc-relay",
+ "btc-relay 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "democracy",
  "escrow",
@@ -2990,11 +3080,11 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "issue",
  "module-btc-relay-rpc-runtime-api",
  "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
+ "module-oracle-rpc-runtime-api 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-relay-rpc-runtime-api",
@@ -3030,7 +3120,7 @@ dependencies = [
  "replace",
  "reward",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-api",
  "sp-arithmetic",
@@ -3042,7 +3132,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-transaction-pool",
  "sp-version",
  "staking",
@@ -3055,15 +3145,15 @@ dependencies = [
 [[package]]
 name = "interbtc-standalone"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "clap",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
  "hex-literal",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "interbtc-rpc",
  "interbtc-runtime-standalone",
  "log 0.4.17",
@@ -3131,16 +3221,16 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 [[package]]
 name = "issue"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
- "btc-relay",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
+ "btc-relay 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "oracle 1.2.0",
  "orml-tokens",
  "orml-traits",
@@ -3148,13 +3238,13 @@ dependencies = [
  "parity-scale-codec",
  "refund",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "vault-registry",
 ]
 
@@ -3308,12 +3398,12 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91dc760c341fa81173f9a434931aaf32baad5552b0230cc6c93e8fb7eaad4c19"
 dependencies = [
- "jsonrpsee-client-transport",
+ "jsonrpsee-client-transport 0.10.1",
  "jsonrpsee-core 0.10.1",
- "jsonrpsee-http-client",
+ "jsonrpsee-http-client 0.10.1",
  "jsonrpsee-proc-macros 0.10.1",
  "jsonrpsee-types 0.10.1",
- "jsonrpsee-ws-client",
+ "jsonrpsee-ws-client 0.10.1",
 ]
 
 [[package]]
@@ -3331,6 +3421,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e017217fcd18da0a25296d3693153dd19c8a6aadab330b3595285d075385d1"
+dependencies = [
+ "jsonrpsee-client-transport 0.14.0",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-http-client 0.14.0",
+ "jsonrpsee-proc-macros 0.14.0",
+ "jsonrpsee-types 0.14.0",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client 0.14.0",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-client-transport"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3446,31 @@ dependencies = [
  "http",
  "jsonrpsee-core 0.10.1",
  "jsonrpsee-types 0.10.1",
+ "pin-project 1.0.10",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.3",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce395539a14d3ad4ec1256fde105abd36a2da25d578a291cabe98f45adfdb111"
+dependencies = [
+ "anyhow",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "gloo-net",
+ "http",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-types 0.14.0",
  "pin-project 1.0.10",
  "rustls-native-certs",
  "soketto",
@@ -3400,6 +3531,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16efcd4477de857d4a2195a45769b2fe9ebb54f3ef5a4221d3b014a4fe33ec0b"
+dependencies = [
+ "anyhow",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "hyper 0.14.19",
+ "jsonrpsee-types 0.14.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "jsonrpsee-http-client"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,6 +3565,25 @@ dependencies = [
  "hyper-rustls",
  "jsonrpsee-core 0.10.1",
  "jsonrpsee-types 0.10.1",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc1d8c0e4f455c47df21f8a29f4bbbcb75eb71bfee919b92e92502b48358392"
+dependencies = [
+ "async-trait",
+ "hyper 0.14.19",
+ "hyper-rustls",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-types 0.14.0",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -3462,6 +3636,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874cf3f6a027cebf36cae767feca9aa2e8a8f799880e49eb5540819fcbd8eada"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jsonrpsee-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,14 +3676,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcf76cd316f5d3ad48138085af1f45e2c58c98e02f0779783dbb034d43f7c86"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1fcb257e9b60de22ec3c151106ad1e089ab1c0691d25e3282f1cc7a0c7ba651"
+dependencies = [
+ "jsonrpsee-client-transport 0.14.0",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-types 0.14.0",
+]
+
+[[package]]
 name = "jsonrpsee-ws-client"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd66d18bab78d956df24dd0d2e41e4c00afbb818fda94a98264bdd12ce8506ac"
 dependencies = [
- "jsonrpsee-client-transport",
+ "jsonrpsee-client-transport 0.10.1",
  "jsonrpsee-core 0.10.1",
  "jsonrpsee-types 0.10.1",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee043cb5dd0d51d3eb93432e998d5bae797691a7b10ec4a325e036bcdb48c48a"
+dependencies = [
+ "jsonrpsee-client-transport 0.14.0",
+ "jsonrpsee-core 0.14.0",
+ "jsonrpsee-types 0.14.0",
 ]
 
 [[package]]
@@ -4585,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "module-btc-relay-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
  "module-btc-relay-rpc-runtime-api",
@@ -4598,18 +4820,18 @@ dependencies = [
 [[package]]
 name = "module-btc-relay-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-issue-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
  "module-issue-rpc-runtime-api",
@@ -4622,25 +4844,37 @@ dependencies = [
 [[package]]
 name = "module-issue-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-oracle-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
- "module-oracle-rpc-runtime-api",
+ "module-oracle-rpc-runtime-api 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+]
+
+[[package]]
+name = "module-oracle-rpc-runtime-api"
+version = "1.2.0"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "serde",
+ "sp-api",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -4652,13 +4886,13 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-redeem-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
  "module-redeem-rpc-runtime-api",
@@ -4671,18 +4905,18 @@ dependencies = [
 [[package]]
 name = "module-redeem-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-refund-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
  "module-refund-rpc-runtime-api",
@@ -4695,18 +4929,18 @@ dependencies = [
 [[package]]
 name = "module-refund-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-relay-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
  "module-relay-rpc-runtime-api",
@@ -4719,18 +4953,18 @@ dependencies = [
 [[package]]
 name = "module-relay-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-replace-rpc"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
  "module-replace-rpc-runtime-api",
@@ -4743,21 +4977,21 @@ dependencies = [
 [[package]]
 name = "module-replace-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
 name = "module-vault-registry-rpc"
 version = "0.3.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "jsonrpsee 0.13.1",
- "module-oracle-rpc-runtime-api",
+ "module-oracle-rpc-runtime-api 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "module-vault-registry-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -4768,13 +5002,13 @@ dependencies = [
 [[package]]
 name = "module-vault-registry-rpc-runtime-api"
 version = "0.3.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-support",
- "module-oracle-rpc-runtime-api",
+ "module-oracle-rpc-runtime-api 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "sp-api",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5051,14 +5285,14 @@ dependencies = [
 [[package]]
 name = "nomination"
 version = "0.5.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "oracle 1.2.0",
  "orml-tokens",
  "orml-traits",
@@ -5066,13 +5300,13 @@ dependencies = [
  "parity-scale-codec",
  "reward",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "staking",
  "vault-registry",
 ]
@@ -5315,22 +5549,22 @@ dependencies = [
 [[package]]
 name = "oracle"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "currency",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "staking",
 ]
 
@@ -5347,7 +5581,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "xcm",
  "xcm-builder",
  "xcm-executor",
@@ -5365,7 +5599,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5382,7 +5616,7 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "xcm",
 ]
 
@@ -5397,7 +5631,7 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5412,7 +5646,7 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5443,7 +5677,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5458,7 +5692,7 @@ dependencies = [
  "scale-info",
  "sp-authorship",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5473,7 +5707,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5490,7 +5724,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5513,7 +5747,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5529,7 +5763,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5546,7 +5780,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5560,7 +5794,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5576,7 +5810,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5592,7 +5826,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5612,7 +5846,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-trie",
 ]
 
@@ -5627,7 +5861,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5641,7 +5875,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5657,7 +5891,7 @@ dependencies = [
  "scale-info",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-timestamp",
 ]
 
@@ -5674,7 +5908,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5716,7 +5950,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5731,7 +5965,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -5747,7 +5981,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "xcm",
  "xcm-executor",
 ]
@@ -6074,7 +6308,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -6091,7 +6325,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -6642,29 +6876,29 @@ dependencies = [
 [[package]]
 name = "redeem"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
- "btc-relay",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
+ "btc-relay 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "oracle 1.2.0",
  "orml-tokens",
  "orml-traits",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "vault-registry",
 ]
 
@@ -6711,29 +6945,29 @@ dependencies = [
 [[package]]
 name = "refund"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
- "btc-relay",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
+ "btc-relay 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "oracle 1.2.0",
  "orml-tokens",
  "orml-traits",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "vault-registry",
 ]
 
@@ -6789,16 +7023,16 @@ dependencies = [
 [[package]]
 name = "relay"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
- "btc-relay",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
+ "btc-relay 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "nomination",
  "oracle 1.2.0",
  "orml-tokens",
@@ -6808,13 +7042,13 @@ dependencies = [
  "refund",
  "replace",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "vault-registry",
 ]
 
@@ -6830,16 +7064,16 @@ dependencies = [
 [[package]]
 name = "replace"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
- "btc-relay",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
+ "btc-relay 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "fee",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "nomination",
  "oracle 1.2.0",
  "orml-tokens",
@@ -6847,13 +7081,13 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "vault-registry",
 ]
 
@@ -6914,12 +7148,12 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 [[package]]
 name = "reward"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -6927,7 +7161,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -6998,18 +7232,18 @@ dependencies = [
  "async-trait",
  "backoff",
  "bitcoin 1.1.0",
- "bitcoin 1.2.0",
- "btc-relay",
+ "bitcoin 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
+ "btc-relay 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
  "cfg-if 1.0.0",
  "clap",
  "env_logger 0.8.4",
  "frame-support",
  "futures 0.3.21",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
  "interbtc-standalone",
  "jsonrpsee 0.10.1",
  "log 0.4.17",
- "module-oracle-rpc-runtime-api",
+ "module-oracle-rpc-runtime-api 1.2.0 (git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7)",
  "parity-scale-codec",
  "prometheus 0.12.0",
  "rand 0.7.3",
@@ -7019,7 +7253,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-keyring",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-version",
  "subxt",
  "subxt-client",
@@ -7990,7 +8224,7 @@ dependencies = [
  "serde_json",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8250,6 +8484,22 @@ dependencies = [
 [[package]]
 name = "security"
 version = "1.2.0"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sha2 0.8.2",
+ "sp-core",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
+]
+
+[[package]]
+name = "security"
+version = "1.2.0"
 source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
 dependencies = [
  "frame-support",
@@ -8260,7 +8510,7 @@ dependencies = [
  "sha2 0.8.2",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8309,6 +8559,12 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -8622,7 +8878,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-version",
  "thiserror",
 ]
@@ -8649,7 +8905,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8663,7 +8919,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-debug-derive",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "static_assertions",
 ]
 
@@ -8676,7 +8932,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8688,7 +8944,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8723,7 +8979,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-version",
  "thiserror",
 ]
@@ -8742,7 +8998,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-timestamp",
 ]
 
@@ -8765,7 +9021,7 @@ dependencies = [
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-timestamp",
 ]
 
@@ -8779,7 +9035,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-timestamp",
 ]
 
@@ -8793,7 +9049,7 @@ dependencies = [
  "schnorrkel",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8828,11 +9084,11 @@ dependencies = [
  "secp256k1 0.21.3",
  "secrecy",
  "serde",
- "sp-core-hashing",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
@@ -8845,6 +9101,20 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec864a6a67249f0c8dd3d5acab43623a61677e85ff4f2f9b04b802d2fe780e83"
+dependencies = [
+ "blake2-rfc",
+ "byteorder",
+ "sha2 0.9.9",
+ "sp-std 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
+ "twox-hash",
+]
+
+[[package]]
+name = "sp-core-hashing"
+version = "4.0.0"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24#257cdb558c0decbd1da756b43288d06d02ff77c7"
 dependencies = [
  "blake2",
@@ -8852,7 +9122,7 @@ dependencies = [
  "digest 0.10.3",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "twox-hash",
 ]
 
@@ -8863,7 +9133,7 @@ source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24#2
 dependencies = [
  "proc-macro2",
  "quote",
- "sp-core-hashing",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "syn",
 ]
 
@@ -8893,7 +9163,7 @@ source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24#2
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-storage",
 ]
 
@@ -8912,7 +9182,7 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -8925,7 +9195,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "thiserror",
 ]
 
@@ -8946,7 +9216,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime-interface",
  "sp-state-machine",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
@@ -9040,7 +9310,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9053,7 +9323,7 @@ dependencies = [
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
@@ -9081,7 +9351,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-io",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-wasm-interface",
  "wasmi",
 ]
@@ -9106,7 +9376,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9117,7 +9387,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9135,12 +9405,18 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-trie",
  "thiserror",
  "tracing",
  "trie-root",
 ]
+
+[[package]]
+name = "sp-std"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14804d6069ee7a388240b665f17908d98386ffb0b5d39f89a4099fc7a2a4c03f"
 
 [[package]]
 name = "sp-std"
@@ -9157,7 +9433,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "sp-debug-derive",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9170,7 +9446,7 @@ dependencies = [
  "sp-externalities",
  "sp-io",
  "sp-runtime-interface",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9185,7 +9461,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "thiserror",
 ]
 
@@ -9195,7 +9471,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24#257cdb558c0decbd1da756b43288d06d02ff77c7"
 dependencies = [
  "parity-scale-codec",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -9222,7 +9498,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-trie",
 ]
 
@@ -9236,7 +9512,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "thiserror",
  "trie-db",
  "trie-root",
@@ -9254,7 +9530,7 @@ dependencies = [
  "serde",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -9278,7 +9554,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log 0.4.17",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "wasmi",
  "wasmtime",
 ]
@@ -9319,12 +9595,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staking"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "orml-tokens",
  "orml-traits",
  "parity-scale-codec",
@@ -9334,7 +9610,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9544,12 +9820,12 @@ dependencies = [
 [[package]]
 name = "supply"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -9557,7 +9833,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
 ]
 
 [[package]]
@@ -9743,6 +10019,15 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -10297,16 +10582,16 @@ dependencies = [
 [[package]]
 name = "vault-registry"
 version = "1.2.0"
-source = "git+https://github.com/interlay/interbtc?rev=825030f2caaf741c811568b24d42d1a2547810f7#825030f2caaf741c811568b24d42d1a2547810f7"
+source = "git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version#362f5240eee1e2079d1833ec3eebc6804fa63446"
 dependencies = [
- "bitcoin 1.2.0",
+ "bitcoin 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "currency",
  "fee",
  "fixed-hash",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "interbtc-primitives",
+ "interbtc-primitives 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "log 0.4.17",
  "oracle 1.2.0",
  "orml-tokens",
@@ -10315,14 +10600,31 @@ dependencies = [
  "parity-scale-codec",
  "reward",
  "scale-info",
- "security",
+ "security 1.2.0 (git+https://github.com/savudani8/interbtc?branch=feature/vault-release-version)",
  "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "staking",
+]
+
+[[package]]
+name = "vaultvisor"
+version = "0.0.1"
+dependencies = [
+ "clap",
+ "env_logger 0.7.1",
+ "hex",
+ "jsonrpsee 0.14.0",
+ "log 0.4.17",
+ "parity-scale-codec",
+ "serde_json",
+ "sp-core",
+ "sp-core-hashing 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -10431,6 +10733,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -10962,7 +11266,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "xcm",
  "xcm-executor",
 ]
@@ -10980,7 +11284,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 4.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "xcm",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
   "vault",
   "bitcoin",
   "faucet",
-  "service"
+  "service",
+  "vaultvisor"
 ]
 
 [patch.crates-io]

--- a/args.txt
+++ b/args.txt
@@ -1,0 +1,8 @@
+--bitcoin-rpc-url http://localhost:18443 \
+--bitcoin-rpc-user rpcuser \
+--bitcoin-rpc-pass rpcpassword \
+--keyfile keyfile.json \
+--keyname 0x124809d7f1c144393dca887c1e00ce5f833db196dbf5eba66ccd12fed1723144 \
+--faucet-url http://localhost:3033 \ 
+--auto-register=KSM=faucet \
+--btc-parachain-url ws://localhost:9944

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -52,7 +52,9 @@ bitcoin = { path = "../bitcoin"}
 
 # Dependencies for the testing utils for integration tests
 tempdir = { version = "0.3.7", optional = true }
-interbtc = { package = "interbtc-standalone", git = "https://github.com/interlay/interbtc", rev = "825030f2caaf741c811568b24d42d1a2547810f7", optional = true }
+# interbtc = { package = "interbtc-standalone", git = "https://github.com/interlay/interbtc", rev = "825030f2caaf741c811568b24d42d1a2547810f7", optional = true }
+# interbtc = { path = "../../interbtc/interbtc", package = "interbtc-standalone", optional = true }
+interbtc = { git = "https://github.com/savudani8/interbtc", branch = "feature/vault-release-version", package = "interbtc-standalone", optional = true }
 rand = { version = "0.7", optional = true }
 
 [dependencies.primitives]

--- a/vault/Cargo.toml
+++ b/vault/Cargo.toml
@@ -15,7 +15,7 @@ parachain-metadata-kintsugi-testnet = ["runtime/parachain-metadata-kintsugi-test
 
 [dependencies]
 thiserror = "1.0"
-clap = "3.1"
+clap = { version = "3.1.0", features = ["derive"]}
 tokio = { version = "1.0", features = ["full"] }
 tokio-metrics = { version = "0.1.0", default-features = false }
 serde = "1.0.136"

--- a/vault/tests/vault_integration_tests.rs
+++ b/vault/tests/vault_integration_tests.rs
@@ -162,6 +162,23 @@ async fn pay_redeem_from_vault_wallet(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_check_provider() {
+    service::init_subscriber();
+
+    let (client, _tmp_dir) = default_provider_client(AccountKeyring::Alice).await;
+
+    let root_provider = setup_provider(client.clone(), AccountKeyring::Alice).await;
+    let relayer_provider = setup_provider(client.clone(), AccountKeyring::Bob).await;
+    let vault_provider = setup_provider(client.clone(), AccountKeyring::Charlie).await;
+    let vault_id = VaultId::new(
+        AccountKeyring::Charlie.into(),
+        DEFAULT_TESTING_CURRENCY,
+        DEFAULT_WRAPPED_CURRENCY,
+    );
+    tokio::time::sleep(Duration::from_secs(1200000)).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_report_vault_theft_succeeds() {
     service::init_subscriber();
 

--- a/vaultvisor/Cargo.toml
+++ b/vaultvisor/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vaultvisor"
+version = "0.0.1"
+authors = ["Interlay <contact@interlay.io>"]
+edition = "2018"
+description = "The Vaultvisor runs and auto-updates Vault clients across multiple networks (Interlay, Kintsugi, testnets)."
+
+
+[dependencies]
+clap = "3.1"
+sp-core-hashing = "4.0.0"
+hex = "0.4.3"
+tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }
+jsonrpsee = { version = "0.14.0", features = ["macros", "jsonrpsee-types", "client", "jsonrpsee-ws-client", "jsonrpsee-client-transport"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+serde_json = "1.0.71"
+thiserror = "1.0.0"
+log = "0.4.0"
+env_logger = "0.7.1"

--- a/vaultvisor/README.md
+++ b/vaultvisor/README.md
@@ -1,0 +1,59 @@
+# Vaultvisor
+
+Auto-updater software for the vault client. On crash or termination, it restarts the vault to remove the need for running as systemd.
+
+
+```bash
+USAGE:
+    vaultvisor --chain-rpc <CHAIN_RPC> --vault-config-file <VAULT_CONFIG_FILE>
+
+OPTIONS:
+        --chain-rpc <CHAIN_RPC>                    
+    -h, --help                                     Print help information
+    -V, --version                                  Print version information
+        --vault-config-file <VAULT_CONFIG_FILE>    
+```
+
+## Run
+Create a vault config file, with the same structure as the command-line arguments passed to the vault client binary.
+Avoid all quotation marks, as these may cause parsing issues.
+
+Example:
+```bash
+--bitcoin-rpc-url http://localhost:18443 \
+--bitcoin-rpc-user rpcuser \
+--bitcoin-rpc-pass rpcpassword \
+--keyfile keyfile.json \
+--keyname 0x124809d7f1c144393dca887c1e00ce5f833db196dbf5eba66ccd12fed1723144 \
+--faucet-url http://localhost:3033 \ 
+--auto-register=KSM=faucet \
+--btc-parachain-url ws://localhost:9944
+```
+
+Pass the path to the file to the vaultvisor, along with the websocket URL of the parachain (the same value as that 
+of the `btc-parachain-url` flag). Example:
+```bash
+./vaultvisor --chain-rpc 'ws://localhost:9944'   --vault-config-file args.txt
+```
+
+## Test
+To manually test with the example configuration above, run a local Bitcoin Regtest network and dev mode Interbtc Parachain.
+
+Bitcoin Regtest:
+```bash
+bitcoind -regtest
+```
+
+Interbtc Parachain (WIP on Dan's fork):
+```bash
+git clone -b feature/vault-release-version https://github.com/savudani8/interbtc
+cd interbtc
+cargo run --bin interbtc-standalone -- --dev
+```
+
+Go to the [apps](https://polkadot.js.org/apps/) explorer on the local node and use sudo to send a `VaultRegistry::setClientRelease` extrinsic with version `1.14.0` and a random 32 byte value for the checksum (not used yet), e.g. `0x122132098310183201928012823109812098210198201298012980981098211`.
+
+Run the vaultvisor:
+```bash
+./vaultvisor --chain-rpc 'ws://localhost:9944' --vault-config-file args.txt
+```

--- a/vaultvisor/src/error.rs
+++ b/vaultvisor/src/error.rs
@@ -1,0 +1,20 @@
+#![allow(clippy::enum_variant_names)]
+
+use codec::Error as CodecError;
+use jsonrpsee::core::Error as JsonRpcCoreError;
+use std::io::Error as OsError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("CodecError: {0}")]
+    CodecError(#[from] CodecError),
+    #[error("JsonRpcCoreError: {0}")]
+    JsonRpcCoreError(#[from] JsonRpcCoreError),
+    #[error("System command error: {0}")]
+    OsError(#[from] OsError),
+    // #[error("JsonRpcHttpError: {0}")]
+    // JsonRpcHttpError(#[from] JsonRpcHttpError),
+    #[error("Failed to derive the release name of the vault")]
+    ClientNameDerivationError,
+}

--- a/vaultvisor/src/main.rs
+++ b/vaultvisor/src/main.rs
@@ -1,0 +1,83 @@
+mod error;
+mod vaultvisor;
+
+use clap::Parser;
+use vaultvisor::{get_release, ws_client};
+
+use std::{
+    fmt::Debug,
+    fs,
+    path::Path,
+    process::{Command, Stdio},
+    str,
+};
+
+use error::Error;
+
+use crate::vaultvisor::{does_vault_binary_exist, run_vault_binary};
+
+#[derive(Parser, Debug, Clone)]
+#[clap(author, version, about, long_about = None)]
+struct Opts {
+    #[clap(long)]
+    chain_rpc: String,
+
+    #[clap(long)]
+    vault_config_file: String,
+}
+
+fn get_args_from_file(file: &str) -> Vec<String> {
+    let args_string = fs::read_to_string(Path::new(file))
+        .expect("Something went wrong reading the vault config file.")
+        // Remove newlines and escape characters
+        .replace(&['\n', '\\'][..], " ");
+
+    // split entries to match the format of `Command::args`
+    args_string
+        .split(' ')
+        .filter(|arg| !arg.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    env_logger::init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, log::LevelFilter::Info.as_str()),
+    );
+    let opts: Opts = Opts::parse();
+    let vault_args = get_args_from_file(&opts.vault_config_file);
+    let rpc_client = ws_client(&opts.chain_rpc).await?;
+    log::info!("Vaultvisor connected to the parachain",);
+    let release = get_release(&rpc_client).await?;
+
+    if !does_vault_binary_exist(&release)? {
+        Command::new("wget")
+            .arg(release.uri.clone())
+            .stdout(Stdio::inherit())
+            .spawn()?
+            .wait_with_output()?;
+        // TODO: Move the binary to a user-specified path?
+        log::info!(
+            "Downloaded vault release v{} from {}",
+            release.semver_version,
+            release.uri
+        );
+        Command::new("chmod")
+            .arg("+x")
+            .arg(release.binary_name.clone())
+            .stdout(Stdio::inherit())
+            .spawn()?
+            .wait_with_output()?;
+    } else {
+        log::info!("Vault binary already exists, skipping download.")
+    }
+
+    loop {
+        match run_vault_binary(&release.binary_name, vault_args.clone()).await {
+            Err(e) => log::error!("Vault binary crashed: {:?}", e),
+            Ok(_) => log::error!("Vault binary finished execution unexpectedly."),
+        }
+        log::info!("Restarting vault...");
+    }
+}

--- a/vaultvisor/src/vaultvisor.rs
+++ b/vaultvisor/src/vaultvisor.rs
@@ -1,0 +1,149 @@
+use crate::error::Error;
+use codec::{Decode, Encode};
+use jsonrpsee::{
+    core::{
+        client::{Client as WsClient, ClientT},
+        JsonValue,
+    },
+    rpc_params,
+    ws_client::WsClientBuilder,
+};
+use sp_core::Bytes;
+use sp_core_hashing::twox_128;
+
+use std::{
+    fmt::Debug,
+    process::{Command, Stdio},
+    str,
+};
+
+pub const RELEASE_BASE_URL: &str = "https://github.com/interlay/interbtc-clients/releases/download";
+pub const PARACHAIN_MODULE: &str = "VaultRegistry";
+pub const RELEASE_VERSION_STORAGE_ITEM: &str = "LatestClientRelease";
+
+#[derive(Encode, Decode, Default, Eq, PartialEq, Debug)]
+pub struct RawClientRelease {
+    /// The semver version, where the zero-index element is the major version
+    pub version: [u32; 3],
+    /// SHA256 checksum of the client binary
+    pub checksum: [u8; 32],
+}
+
+#[derive(Debug, Clone)]
+pub struct ClientRelease {
+    // `checksum` not currently included on purpose, as it is not yet used.
+    pub uri: String,
+    pub binary_name: String,
+    pub semver_version: String,
+}
+
+pub(crate) fn compute_storage_key(module: String, key: String) -> String {
+    let module = twox_128(module.as_bytes());
+    let item = twox_128(key.as_bytes());
+    let key = hex::encode([module, item].concat());
+    format!("0x{}", key)
+}
+
+pub async fn query_storage<'a>(
+    ws_client: &'a WsClient,
+    maybe_storage_key: Option<&str>,
+    method: &str,
+) -> Result<Bytes, Error> {
+    let params = maybe_storage_key.map_or(rpc_params![], |key| rpc_params![key]);
+    ws_client.request(method, params).await.map_err(Into::into)
+}
+
+pub async fn read_chain_storage<T: Decode + Debug>(
+    ws_client: &WsClient,
+    maybe_storage_key: Option<&str>,
+) -> Result<T, Error> {
+    let encoded_bytes = query_storage(ws_client, maybe_storage_key, "state_getStorage").await?;
+    let v = encoded_bytes.to_vec();
+    let decoded_entry = T::decode(&mut &v[..])?;
+    Ok(decoded_entry)
+    // TODO: get the following to work. Requires merging this parachain PR: https://github.com/interlay/interbtc/pull/668
+    // Then the metadata needs to be updated in interbtc-clients, so a standalone parachain provider can be
+    // instantiated, as in the other integration tests. With that, it will be possible to simulate sending extrinsics
+    // to upgrade the clients version. It's also possible to run `curi` commands against the RPC endpoint of the
+    // standalone provider.
+}
+
+pub async fn get_release_version(ws_client: &WsClient) -> Result<String, Error> {
+    let storage_key = compute_storage_key(PARACHAIN_MODULE.to_string(), RELEASE_VERSION_STORAGE_ITEM.to_string());
+    let release = read_chain_storage::<RawClientRelease>(ws_client, Some(storage_key.as_str())).await?;
+    // Convert version array (e.g. `[1, 0, 0]`) to semver (e.g. `1.0.0`)
+    // Assumes the version is always three elements long
+    Ok(format!(
+        "{}.{}.{}",
+        release.version[0], release.version[1], release.version[2]
+    ))
+}
+
+pub async fn get_binary_name(ws_client: &WsClient) -> Result<String, Error> {
+    let runtime_version = ws_client
+        .request::<JsonValue>("state_getRuntimeVersion", rpc_params![])
+        .await?;
+    let spec_name = runtime_version
+        .as_object()
+        .ok_or(Error::ClientNameDerivationError)?
+        .get("specName")
+        .ok_or(Error::ClientNameDerivationError)?
+        .as_str()
+        .ok_or(Error::ClientNameDerivationError)?
+        .to_string();
+    Ok(spec_name_to_vault_binary(spec_name))
+}
+
+fn spec_name_to_vault_binary(spec_name: String) -> String {
+    // This function is based on the chainspec chain identification logic in the parachain.
+    // Source: https://github.com/interlay/interbtc/blob/594d4d023f74fb7a6e935ad71f4292ca949779ed/parachain/src/command.rs#L50
+    let base_name = "vault-";
+    let suffix = if spec_name.starts_with("interlay") {
+        "parachain-metadata-interlay"
+    } else if spec_name.starts_with("kintsugi") {
+        "parachain-metadata-kintsugi"
+    } else if spec_name.starts_with("testnet-interlay") {
+        "parachain-metadata-interlay-testnet"
+    } else if spec_name.starts_with("testnet-kintsugi") || spec_name.starts_with("testnet-parachain") {
+        "parachain-metadata-testnet-kintsugi"
+    } else {
+        // standalone node
+        "standalone-metadata"
+    };
+    format!("{}{}", base_name, suffix)
+}
+
+pub async fn get_release(ws_client: &WsClient) -> Result<ClientRelease, Error> {
+    let version = get_release_version(ws_client).await?;
+    let binary_name = get_binary_name(ws_client).await?;
+    let uri = format!("{}/{}/{}", RELEASE_BASE_URL, version, binary_name);
+    Ok(ClientRelease {
+        uri,
+        binary_name,
+        semver_version: version,
+    })
+}
+
+pub async fn ws_client(url: &str) -> Result<WsClient, Error> {
+    Ok(WsClientBuilder::default().build(url).await?)
+}
+
+pub async fn run_vault_binary(binary_name: &str, args: Vec<String>) -> Result<(), Error> {
+    Command::new(format!("./{}", binary_name))
+        .args(args)
+        .stdout(Stdio::inherit())
+        .spawn()?
+        .wait_with_output()?;
+    Ok(())
+}
+
+pub fn does_vault_binary_exist(release: &ClientRelease) -> Result<bool, Error> {
+    // TODO: check if the existing binary has the correct version and do not crash.
+    let output = Command::new("ls")
+        .arg(release.binary_name.clone())
+        .stdout(Stdio::piped())
+        .output()?;
+    // The `ls` command prints results followed by an endline. Remove the endline charachter.
+    let stdout = String::from_utf8(output.stdout).unwrap().replace('\n', "");
+    Ok(stdout.eq(&release.binary_name))
+}


### PR DESCRIPTION
# Vaultvisor

Auto-updater software for the vault client. On crash or termination, it restarts the vault to remove the need for running as systemd. 

On startup, the release version is read from the `ClientRelease` storage value inside the `VaultRegistry` pallet. This is done using `jsonrpsee` to avoid maintaining metadata for `subxt`. As long as the storage key of the Client Release remains the same, the auto-updater will work.

Testing is done manually at the moment (check `vaultvisor/README.md`) because integration tests require the chain metadata of the [new feature](https://github.com/interlay/interbtc/pull/668) to be added to the clients.

TODO in future PRs:

- [ ] integration tests
- [ ] actually download new versions
- [ ] switch to a JSON format for the config file