### PR TITLE
chore: upgrade to nightly-2022-06-20

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-02-08"
+channel = "nightly-2022-06-20"
 components = [ "rustfmt", "rls" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Requires a parachain upgrade due to a compilation error in the currency crate.