### PR TITLE
fix: restart child on crash, kill child on runner crash

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -5,7 +5,7 @@ testnets).
 
 > **IMPORTANT**
 > 
-> It is CRITICAL that the runner is shut down gracefully, otherwise the spawned vault process will keep running. If there are multiple running vault executables for the same [Vault ID(s)](https://docs.interlay.io/#/vault/overview?id=multi-collateral-system), redeem requests be fulfilled by all vault executables, leading to double-spending the BTC in the vault's wallet! The Vault operator will need to provide its own BTC to cover for the loss, to avoid having its [collateral slashed](https://docs.interlay.io/#/guides/bridge?id=_4-optional-retry-or-reimburse-your-request).
+> It is CRITICAL that the runner is shut down gracefully, otherwise the spawned vault process will keep running. If there are multiple running vault executables for the same [Vault ID(s)](https://docs.interlay.io/#/vault/overview?id=multi-collateral-system), redeem requests will be fulfilled by all vault executables, leading to double-spending the BTC in the vault's wallet! The Vault operator will need to provide its own BTC to cover for the loss, to avoid having its [collateral slashed](https://docs.interlay.io/#/guides/bridge?id=_4-optional-retry-or-reimburse-your-request).
 > 
 > Supported process signals for graceful termination: `SIGHUP`, `SIGTERM`, `SIGINT`, `SIGQUIT`.
 

--- a/runner/src/error.rs
+++ b/runner/src/error.rs
@@ -35,8 +35,6 @@ pub enum Error {
     ChildProcessExists,
     #[error("Failed to terminate child process")]
     ProcessTerminationFailure,
-    #[error("Auto-updater terminated unexpectedly")]
-    AutoUpdaterTerminated,
 }
 
 impl<E: Into<Error> + Sized> From<BackoffError<E>> for Error {


### PR DESCRIPTION
- Restarts child process (vault) if crashed, checked in the main loop of `auto_update`, every `BLOCK_TIME`
- Kills child process before the runner shuts down because of an error. This is implemented both by implementing the `drop` trait for `Runner` and by calling `terminate_proc_and_wait()` if `auto_update()` ever returns