### PR TITLE
feat(runner): upload artifact

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -83,3 +83,9 @@ jobs:
           name: faucet-${{ matrix.metadata }}-${{ github.sha }}
           path: target/release/faucet
           retention-days: 10
+      - name: upload artifacts - runner
+        uses: actions/upload-artifact@v2
+        with:
+          name: runner-${{ github.sha }}
+          path: target/release/runner
+          retention-days: 10

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -84,6 +84,7 @@ jobs:
           path: target/release/faucet
           retention-days: 10
       - name: upload artifacts - runner
+        if: matrix.metadata == 'parachain-metadata-kintsugi-testnet'
         uses: actions/upload-artifact@v2
         with:
           name: runner-${{ github.sha }}


### PR DESCRIPTION
Uploads `runner` build artifact so it can be released. Since it does not depend on any metadata feature it only runs once, on the `parachain-metadata-kintsugi-testnet` step (since that step is also the only one to run tests).