### PR TITLE
fix(runner): crash edge case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12674,9 +12674,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.25.1"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e4bc9213f734126e2be3e2e118dbc9b909c37487d8d755822bc90f70ae62a"
+checksum = "71eb43e528fdc239f08717ec2a378fdb017dddbc3412de15fff527554591a66c"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/runner/src/error.rs
+++ b/runner/src/error.rs
@@ -23,14 +23,10 @@ pub enum Error {
     HttpError(#[from] ReqwestError),
     #[error("UrlParseError: {0}")]
     UrlParseError(#[from] UrlParseError),
-    #[error("Failed to derive the release name of the vault")]
-    ClientNameDerivationError,
     #[error("Integer conversion error")]
     IntegerConversionError,
     #[error("A client release has not been downloaded")]
     NoDownloadedRelease,
-    #[error("No child process has been spawned")]
-    NoChildProcess,
     #[error("A child process is already running")]
     ChildProcessExists,
     #[error("Failed to terminate child process")]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -14,17 +14,17 @@ use crate::runner::{retry_with_log_async, ws_client, Runner};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(version, author, about, trailing_var_arg = true)]
-struct Opts {
+pub struct Opts {
     /// Parachain websocket URL.
     #[clap(long)]
-    parachain_ws: String,
+    pub parachain_ws: String,
 
     /// Download path for the vault executable.
     #[clap(long, default_value = ".")]
-    download_path: PathBuf,
+    pub download_path: PathBuf,
 
     /// CLI arguments to pass to the vault executable.
-    vault_args: Vec<String>,
+    pub vault_args: Vec<String>,
 }
 
 #[tokio::main]
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Error> {
     .await?;
     log::info!("Connected to the parachain");
 
-    let runner = Runner::new(rpc_client, opts.vault_args, opts.download_path);
+    let runner = Runner::new(rpc_client, opts);
     let shutdown_signals = Signals::new(&[SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
     Runner::run(Box::new(runner), shutdown_signals).await?;
     Ok(())


### PR DESCRIPTION
- The name of the downloaded executable is no longer determined based on the release URL, but set as a constant (`vault`, instead of e.g. `vault-parachain-metadata-kintsugi-testnet`). This is for compatibility with the interlay docs.
- Handles edge case that led to the runner crashing, in `terminate_proc_and_wait`. If the runner received a termination signal but had no spawned child process, `terminate_proc_and_wait` would propagate an error to the `select!` expression, which performs no further error handling.