### PR TITLE
refactor: propagate reason for shutdown

### DIFF
--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -73,7 +73,7 @@ cfg_if::cfg_if! {
 }
 
 type RuntimeApi = metadata::RuntimeApi<InterBtcRuntime, PolkadotExtrinsicParams<InterBtcRuntime>>;
-pub(crate) type ShutdownSender = tokio::sync::broadcast::Sender<Option<()>>;
+pub(crate) type ShutdownSender = tokio::sync::broadcast::Sender<()>;
 pub(crate) type FeeRateUpdateSender = tokio::sync::broadcast::Sender<FixedU128>;
 pub type FeeRateUpdateReceiver = tokio::sync::broadcast::Receiver<FixedU128>;
 
@@ -267,7 +267,7 @@ impl InterBtcParachain {
                 {
                     Err(_) => {
                         log::warn!("Timeout on transaction submission - restart required");
-                        let _ = self.shutdown_tx.send(Some(()));
+                        let _ = self.shutdown_tx.send(());
                         Err(Error::Timeout)
                     }
                     Ok(x) => Ok(x?),

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -51,21 +51,24 @@ pub async fn process_issue_requests<B: BitcoinCoreApi + Clone + Send + Sync + 's
     let mut stream =
         bitcoin::stream_in_chain_transactions(bitcoin_core.clone(), btc_start_height, num_confirmations).await;
 
-    while let Some(Ok((block_hash, transaction))) = stream.next().await {
-        tokio::spawn(
-            process_transaction_and_execute_issue(
-                bitcoin_core.clone(),
-                btc_parachain.clone(),
-                issue_set.clone(),
-                num_confirmations,
-                block_hash,
-                transaction,
-                random_delay.clone(),
-            )
-            .map_err(|e| {
-                tracing::warn!("Failed to execute issue request: {}", e.to_string());
-            }),
-        );
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok((block_hash, transaction)) => tokio::spawn(
+                process_transaction_and_execute_issue(
+                    bitcoin_core.clone(),
+                    btc_parachain.clone(),
+                    issue_set.clone(),
+                    num_confirmations,
+                    block_hash,
+                    transaction,
+                    random_delay.clone(),
+                )
+                .map_err(|e| {
+                    tracing::warn!("Failed to execute issue request: {}", e.to_string());
+                }),
+            ),
+            Err(err) => return Err(err.into()),
+        };
     }
 
     // stream closed, restart client

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -377,12 +377,16 @@ impl Service<VaultServiceConfig> for VaultService {
             Ok(_) => Ok(()),
             Err(Error::RuntimeError(err)) => Err(ServiceError::RuntimeError(err)),
             Err(Error::BitcoinError(err)) => Err(ServiceError::BitcoinError(err)),
+            Err(Error::ServiceError(err)) => Err(err),
             Err(err) => Err(ServiceError::Other(err.to_string())),
         }
     }
 }
 
-async fn run_and_monitor_tasks(shutdown_tx: ShutdownSender, items: Vec<(&str, ServiceTask)>) {
+async fn run_and_monitor_tasks(
+    shutdown_tx: ShutdownSender,
+    items: Vec<(&str, ServiceTask)>,
+) -> Result<(), ServiceError> {
     let (metrics_iterators, tasks): (HashMap<String, _>, Vec<_>) = items
         .into_iter()
         .filter_map(|(name, task)| {
@@ -405,7 +409,14 @@ async fn run_and_monitor_tasks(shutdown_tx: ShutdownSender, items: Vec<(&str, Se
         publish_tokio_metrics(metrics_iterators),
     ));
 
-    let _ = join(tokio_metrics, join_all(tasks)).await;
+    match join(tokio_metrics, join_all(tasks)).await {
+        (Ok(Err(err)), _) => Err(err),
+        (_, results) => results
+            .into_iter()
+            .find(|res| matches!(res, Ok(Err(_))))
+            .and_then(|res| res.ok())
+            .unwrap_or(Ok(())),
+    }
 }
 
 type Task = Pin<Box<dyn Future<Output = Result<(), service::Error>> + Send + 'static>>;
@@ -742,9 +753,9 @@ impl VaultService {
             ),
         ];
 
-        run_and_monitor_tasks(self.shutdown.clone(), tasks).await;
-
-        Ok(())
+        run_and_monitor_tasks(self.shutdown.clone(), tasks)
+            .await
+            .map_err(Error::ServiceError)
     }
 
     async fn maybe_register_public_key(&self) -> Result<(), Error> {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Errors which occur in one of the "tasks" are not propagated to the `ConnectionManager` so we should read this reason from the shutdown channel.