### PR TITLE
feat(vault): handle termination signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13641,6 +13641,8 @@ dependencies = [
  "serde",
  "service",
  "sha2 0.8.2",
+ "signal-hook",
+ "signal-hook-tokio",
  "sp-arithmetic",
  "sp-core",
  "sp-keyring",

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -2,6 +2,7 @@ use bitcoin::Error as BitcoinError;
 use hyper::{http::Error as HyperHttpError, Error as HyperError};
 use runtime::Error as RuntimeError;
 use serde_json::Error as SerdeJsonError;
+use std::io::Error as IoError;
 use thiserror::Error;
 use tokio::task::JoinError as TokioJoinError;
 
@@ -25,6 +26,8 @@ pub enum Error {
     BitcoinError(#[from] BitcoinError),
     #[error("TokioError: {0}")]
     TokioError(#[from] TokioJoinError),
+    #[error("System I/O error: {0}")]
+    IoError(#[from] IoError),
 
     /// Other error
     #[error("Other: {0}")]

--- a/vault/Cargo.toml
+++ b/vault/Cargo.toml
@@ -25,6 +25,8 @@ futures = "0.3.5"
 async-trait = "0.1.40"
 sha2 = "0.8.2"
 git-version = "0.3.4"
+signal-hook = "0.3.14"
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 
 lazy_static = "1.4"
 

--- a/vault/src/main.rs
+++ b/vault/src/main.rs
@@ -1,8 +1,11 @@
 use clap::Parser;
+use futures::Future;
 use runtime::InterBtcSigner;
 use service::{warp, warp::Filter, ConnectionManager, Error, MonitoringConfig, ServiceConfig};
+use signal_hook::consts::*;
+use signal_hook_tokio::Signals;
 use std::net::{Ipv4Addr, SocketAddr};
-
+use tokio_stream::StreamExt;
 use vault::{
     metrics::{self, increment_restart_counter},
     VaultService, VaultServiceConfig, ABOUT, AUTHORS, NAME, VERSION,
@@ -34,6 +37,24 @@ pub struct Opts {
     /// Prometheus monitoring settings.
     #[clap(flatten)]
     pub monitoring: MonitoringConfig,
+}
+
+async fn catch_signals<F>(mut shutdown_signals: Signals, future: F) -> Result<(), Error>
+where
+    F: Future<Output = Result<(), Error>>,
+{
+    tokio::select! {
+        res = future => {
+            let _ = res?;
+        },
+        signal_option = shutdown_signals.next() => {
+            if let Some(signal) = signal_option {
+                tracing::info!("Received termination signal: {}", signal);
+            }
+            tracing::info!("Shutting down...");
+        }
+    }
+    Ok(())
 }
 
 async fn start() -> Result<(), Error> {
@@ -81,11 +102,37 @@ async fn start() -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() {
-    let exit_code = if let Err(err) = start().await {
+    let exit_code = if let Err(err) = catch_signals(
+        Signals::new(&[SIGHUP, SIGTERM, SIGINT, SIGQUIT]).expect("Failed to set up signal listener."),
+        start(),
+    )
+    .await
+    {
         tracing::error!("Exiting: {}", err);
         1
     } else {
         0
     };
     std::process::exit(exit_code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{thread, time::Duration};
+
+    #[tokio::test]
+    async fn test_vault_termination_signal() {
+        let shutdown_signals = Signals::new(&[SIGHUP, SIGTERM, SIGINT, SIGQUIT]).unwrap();
+        let task = tokio::spawn(catch_signals(shutdown_signals, async {
+            tokio::time::sleep(Duration::from_millis(100_000)).await;
+            Ok(())
+        }));
+        // Wait for the signals iterator to be polled
+        // This `sleep` is based on the test case in `signal-hook-tokio` itself:
+        // https://github.com/vorner/signal-hook/blob/a9e5ca5e46c9c8e6de89ff1b3ce63c5ff89cd708/signal-hook-tokio/tests/tests.rs#L50
+        thread::sleep(Duration::from_millis(100));
+        signal_hook::low_level::raise(SIGTERM).unwrap();
+        task.await.unwrap().unwrap();
+    }
 }


### PR DESCRIPTION
Handles termination signals, using a similar approach to https://github.com/interlay/interbtc-clients/pull/330.

This feature makes way for cleaning up the PID file on shutdown, in https://github.com/interlay/interbtc-clients/pull/347

I tried simplifying the scaffolding required for the mocks but still couldn't find a way around using trait methods only as an indirection to the actual implementation.

This feature is opt-in in the code (call `catch_signals()` instead of `start()`) and could be moved to the `service` crate instead.

---

Panics

    If the given signal is [forbidden][crate::FORBIDDEN].
    If the signal number is negative or larger than internal limit. The limit should be larger than any supported signal the OS supports.
    If the relevant Exfiltrator does not support this particular signal. The default [SignalOnly] one supports all signals. <- we're using the default