### PR TITLE
refactor: remove generics on BitcoinCoreApi methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,6 @@ version = "1.1.0"
 dependencies = [
  "async-trait",
  "backoff 0.3.0",
- "bitcoin 1.2.0",
  "bitcoincore-rpc",
  "clap",
  "esplora-btc-api",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -5,11 +5,10 @@ authors = ["Interlay <contact@interlay.io>"]
 edition = "2018"
 
 [features]
-default = ["interbtc"]
+default = []
 regtest-mine-on-tx = []
 regtest-manual-mining = []
 cli = ["clap"]
-interbtc = ["interbtc-bitcoin"]
 uses-bitcoind = []
 
 [dependencies]
@@ -36,12 +35,6 @@ serde_json = "1.0.82"
 
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
-
-[dependencies.interbtc-bitcoin]
-git = "https://github.com/interlay/interbtc"
-rev = "2ddb5eba6fdb42125805bf15d8a4caf30556e0ab"
-package = "bitcoin"
-optional = true
 
 [dev-dependencies]
 mockall = "0.8.1"

--- a/bitcoin/src/addr.rs
+++ b/bitcoin/src/addr.rs
@@ -1,90 +1,4 @@
-use crate::{
-    secp256k1::SecretKey, Address, ConversionError, Error, Hash, Network, Payload, PubkeyHash, Script, ScriptHash,
-    WPubkeyHash, WScriptHash,
-};
-use sp_core::H160;
-use std::str::FromStr;
-
-pub trait PartialAddress: Sized + Eq + PartialOrd {
-    /// Decode the `PartialAddress` from the `Payload` type.
-    ///
-    /// # Arguments
-    /// * `payload` - Bitcoin payload (P2PKH, P2SH, P2WPKH)
-    fn from_payload(payload: Payload) -> Result<Self, ConversionError>;
-
-    /// Decode the `PartialAddress` from a string.
-    ///
-    /// # Arguments
-    /// * `btc_address` - encoded Bitcoin address
-    fn decode_str(btc_address: &str) -> Result<Self, ConversionError>;
-
-    /// Encode the `PartialAddress` as a string.
-    ///
-    /// # Arguments
-    /// * `network` - network to prefix
-    fn encode_str(&self, network: Network) -> Result<String, ConversionError> {
-        let address = self.to_address(network)?;
-        Ok(address.to_string())
-    }
-
-    /// Encode the `PartialAddress` as an address that the bitcoin rpc can use.
-    ///
-    /// # Arguments
-    /// * `network` - network to prefix
-    fn to_address(&self, network: Network) -> Result<Address, ConversionError>;
-}
-
-#[cfg(feature = "interbtc")]
-impl PartialAddress for interbtc_bitcoin::Address {
-    fn from_payload(payload: Payload) -> Result<Self, ConversionError> {
-        match payload {
-            Payload::PubkeyHash(hash) => Ok(Self::P2PKH(H160::from(hash.as_hash().into_inner()))),
-            Payload::ScriptHash(hash) => Ok(Self::P2SH(H160::from(hash.as_hash().into_inner()))),
-            Payload::WitnessProgram { version: _, program } => {
-                if program.len() == 20 {
-                    Ok(Self::P2WPKHv0(H160::from_slice(program.as_slice())))
-                } else {
-                    Err(ConversionError::InvalidPayload)
-                }
-            }
-        }
-    }
-
-    fn decode_str(btc_address: &str) -> Result<Self, ConversionError> {
-        let addr = Address::from_str(btc_address)?;
-        Self::from_payload(addr.payload)
-    }
-
-    fn to_address(&self, network: Network) -> Result<Address, ConversionError> {
-        let script = match self {
-            Self::P2PKH(hash) => Script::new_p2pkh(&PubkeyHash::from_slice(hash.as_bytes())?),
-            Self::P2SH(hash) => Script::new_p2sh(&ScriptHash::from_slice(hash.as_bytes())?),
-            Self::P2WPKHv0(hash) => Script::new_v0_wpkh(&WPubkeyHash::from_slice(hash.as_bytes())?),
-            Self::P2WSHv0(hash) => Script::new_v0_wsh(&WScriptHash::from_slice(hash.as_bytes())?),
-        };
-
-        let payload = Payload::from_script(&script).ok_or(ConversionError::InvalidPayload)?;
-        Ok(Address { payload, network })
-    }
-}
-
-impl PartialAddress for Payload {
-    fn from_payload(payload: Payload) -> Result<Self, ConversionError> {
-        Ok(payload)
-    }
-
-    fn decode_str(btc_address: &str) -> Result<Self, ConversionError> {
-        let address = Address::from_str(btc_address)?;
-        Ok(address.payload)
-    }
-
-    fn to_address(&self, network: Network) -> Result<Address, ConversionError> {
-        Ok(Address {
-            network,
-            payload: self.clone(),
-        })
-    }
-}
+use crate::{secp256k1::SecretKey, Error};
 
 pub fn calculate_deposit_secret_key(vault_key: SecretKey, issue_key: SecretKey) -> Result<SecretKey, Error> {
     let mut deposit_key = vault_key;
@@ -99,15 +13,6 @@ mod tests {
     use rand::{thread_rng, Rng};
     use secp256k1::{constants::SECRET_KEY_SIZE, PublicKey, Secp256k1, SecretKey};
     use sp_core::H256;
-
-    #[test]
-    fn test_encode_and_decode_payload() {
-        let addr = "bcrt1q6v2c7q7uv8vu6xle2k9ryfj3y3fuuy4rqnl50f";
-        assert_eq!(
-            addr,
-            Payload::decode_str(addr).unwrap().encode_str(Network::Regtest).unwrap()
-        );
-    }
 
     #[test]
     fn test_calculate_deposit_secret_key() {

--- a/bitcoin/src/iter.rs
+++ b/bitcoin/src/iter.rs
@@ -191,7 +191,7 @@ async fn get_best_block_info<B: BitcoinCoreApi + Clone>(rpc: &B) -> Result<(u32,
 mod tests {
     use super::*;
     use crate::*;
-    pub use bitcoincore_rpc::bitcoin::{Amount, Network, TxMerkleNode};
+    pub use bitcoincore_rpc::bitcoin::{Address, Amount, Network, PublicKey, TxMerkleNode};
     use sp_core::H256;
 
     mockall::mock! {
@@ -208,13 +208,13 @@ mod tests {
             async fn get_transaction(&self, txid: &Txid, block_hash: Option<BlockHash>) -> Result<Transaction, Error>;
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, Error>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, Error>;
-            async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, Error>;
-            async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, Error>;
-            fn dump_derivation_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(&self, public_key: P) -> Result<PrivateKey, Error>;
+            async fn get_new_address(&self) -> Result<Address, Error>;
+            async fn get_new_public_key(&self) -> Result<PublicKey, Error>;
+            fn dump_derivation_key(&self, public_key: &PublicKey) -> Result<PrivateKey, Error>;
             fn import_derivation_key(&self, private_key: &PrivateKey) -> Result<(), Error>;
-            async fn add_new_deposit_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(
+            async fn add_new_deposit_key(
                 &self,
-                public_key: P,
+                public_key: PublicKey,
                 secret_key: Vec<u8>,
             ) -> Result<(), Error>;
             async fn get_best_block_hash(&self) -> Result<BlockHash, Error>;
@@ -229,16 +229,16 @@ mod tests {
                 txid: Txid,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, Error>;
-            async fn create_and_send_transaction<A: PartialAddress + Send + 'static>(
+            async fn create_and_send_transaction(
                 &self,
-                address: A,
+                address: Address,
                 sat: u64,
                 fee_rate: SatPerVbyte,
                 request_id: Option<H256>,
             ) -> Result<Txid, Error>;
-            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(
+            async fn send_to_address(
                 &self,
-                address: A,
+                address: Address,
                 sat: u64,
                 request_id: Option<H256>,
                 fee_rate: SatPerVbyte,
@@ -246,15 +246,15 @@ mod tests {
             ) -> Result<TransactionMetadata, Error>;
             async fn create_or_load_wallet(&self) -> Result<(), Error>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error>;
-            async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync + 'static>(
+            async fn rescan_electrs_for_addresses(
                 &self,
-                addresses: Vec<A>,
+                addresses: Vec<Address>,
             ) -> Result<(), Error>;
             fn get_utxo_count(&self) -> Result<usize, Error>;
-            async fn bump_fee<A: PartialAddress + Send + Sync + 'static>(
+            async fn bump_fee(
                 &self,
                 txid: &Txid,
-                address: A,
+                address: Address,
                 fee_rate: SatPerVbyte,
             ) -> Result<Txid, Error>;
             fn is_in_mempool(&self, txid: Txid) -> Result<bool, Error>;

--- a/runtime/src/addr.rs
+++ b/runtime/src/addr.rs
@@ -1,0 +1,103 @@
+use crate::{BtcAddress, H160};
+use bitcoin::{
+    Address, ConversionError, Hash, Network, Payload, PubkeyHash, Script, ScriptHash, WPubkeyHash, WScriptHash,
+};
+
+pub trait PartialAddress: Sized + Eq + PartialOrd {
+    /// Decode the `PartialAddress` from the `Payload` type.
+    ///
+    /// # Arguments
+    /// * `payload` - Bitcoin payload (P2PKH, P2SH, P2WPKH)
+    fn from_payload(payload: Payload) -> Result<Self, ConversionError>;
+
+    /// Encode the `PartialAddress` into the `Payload` type.
+    fn to_payload(&self) -> Result<Payload, ConversionError>;
+
+    /// Decode the `PartialAddress` from the `Address` type.
+    ///
+    /// # Arguments
+    /// * `address` - Bitcoin address
+    fn from_address(address: Address) -> Result<Self, ConversionError>;
+
+    /// Encode the `PartialAddress` as an address that the bitcoin rpc can use.
+    ///
+    /// # Arguments
+    /// * `network` - network to prefix
+    fn to_address(&self, network: Network) -> Result<Address, ConversionError>;
+}
+
+impl PartialAddress for BtcAddress {
+    fn from_payload(payload: Payload) -> Result<Self, ConversionError> {
+        match payload {
+            Payload::PubkeyHash(hash) => Ok(Self::P2PKH(H160::from(hash.as_hash().into_inner()))),
+            Payload::ScriptHash(hash) => Ok(Self::P2SH(H160::from(hash.as_hash().into_inner()))),
+            Payload::WitnessProgram { version: _, program } => {
+                if program.len() == 20 {
+                    Ok(Self::P2WPKHv0(H160::from_slice(program.as_slice())))
+                } else {
+                    Err(ConversionError::InvalidPayload)
+                }
+            }
+        }
+    }
+
+    fn to_payload(&self) -> Result<Payload, ConversionError> {
+        let script = match self {
+            Self::P2PKH(hash) => Script::new_p2pkh(&PubkeyHash::from_slice(hash.as_bytes())?),
+            Self::P2SH(hash) => Script::new_p2sh(&ScriptHash::from_slice(hash.as_bytes())?),
+            Self::P2WPKHv0(hash) => Script::new_v0_wpkh(&WPubkeyHash::from_slice(hash.as_bytes())?),
+            Self::P2WSHv0(hash) => Script::new_v0_wsh(&WScriptHash::from_slice(hash.as_bytes())?),
+        };
+
+        Payload::from_script(&script).ok_or(ConversionError::InvalidPayload)
+    }
+
+    fn from_address(address: Address) -> Result<Self, ConversionError> {
+        Self::from_payload(address.payload)
+    }
+
+    fn to_address(&self, network: Network) -> Result<Address, ConversionError> {
+        let payload = self.to_payload()?;
+        Ok(Address { payload, network })
+    }
+}
+
+impl PartialAddress for Payload {
+    fn from_payload(payload: Payload) -> Result<Self, ConversionError> {
+        Ok(payload)
+    }
+
+    fn to_payload(&self) -> Result<Payload, ConversionError> {
+        Ok(self.clone())
+    }
+
+    fn from_address(address: Address) -> Result<Self, ConversionError> {
+        Ok(address.payload)
+    }
+
+    fn to_address(&self, network: Network) -> Result<Address, ConversionError> {
+        Ok(Address {
+            network,
+            payload: self.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_encode_and_decode_payload() {
+        let addr = "bcrt1q6v2c7q7uv8vu6xle2k9ryfj3y3fuuy4rqnl50f";
+        assert_eq!(
+            addr,
+            Payload::from_address(Address::from_str(addr).unwrap())
+                .unwrap()
+                .to_address(Network::Regtest)
+                .unwrap()
+                .to_string()
+        );
+    }
+}

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -3,13 +3,13 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
-use crate::{BtcAddress, BtcRelayPallet, InterBtcParachain, RawBlockHeader, H160, H256, U256};
+use crate::{BtcAddress, BtcRelayPallet, InterBtcParachain, PartialAddress, RawBlockHeader, H160, H256, U256};
 use async_trait::async_trait;
 use bitcoin::{
     json,
-    secp256k1::{constants::SECRET_KEY_SIZE, PublicKey, Secp256k1, SecretKey},
+    secp256k1::{self, constants::SECRET_KEY_SIZE, Secp256k1, SecretKey},
     serialize, Address, Amount, BitcoinCoreApi, Block, BlockHash, BlockHeader, Error as BitcoinError, GetBlockResult,
-    Hash, Network, OutPoint, PartialAddress, PartialMerkleTree, PrivateKey, SatPerVbyte, Script, Transaction,
+    Hash, Network, OutPoint, PartialMerkleTree, PrivateKey, PublicKey, SatPerVbyte, Script, Transaction,
     TransactionExt, TransactionMetadata, TxIn, TxOut, Txid, Uint256, PUBLIC_KEY_SIZE,
 };
 use rand::{thread_rng, Rng};
@@ -46,7 +46,9 @@ impl MockBitcoinCore {
             transaction_creation_lock: Arc::new(Mutex::new(())),
         };
 
-        let address = BtcAddress::P2PKH(H160::from([0; 20]));
+        let address = BtcAddress::P2PKH(H160::from([0; 20]))
+            .to_address(Network::Regtest)
+            .unwrap();
         let dummy_tx = Self::generate_normal_transaction(&address, 10000);
         let block = ret.generate_block_with_transaction(&dummy_tx).await;
         let raw_block_header = serialize(&block.header);
@@ -143,9 +145,8 @@ impl MockBitcoinCore {
         block
     }
 
-    fn generate_normal_transaction<A: PartialAddress + Send + 'static>(address: &A, reward: u64) -> Transaction {
-        let address: BtcAddress = BtcAddress::decode_str(&address.encode_str(Network::Regtest).unwrap()).unwrap();
-        let address = Script::from(address.to_script_pub_key().as_bytes().to_vec());
+    fn generate_normal_transaction(address: &Address, reward: u64) -> Transaction {
+        let address = Script::from(address.payload.script_pubkey().as_bytes().to_vec());
 
         let return_to_self_address = BtcAddress::P2PKH(H160::from_slice(&[20; 20]));
         let return_to_self_address = Script::from(return_to_self_address.to_script_pub_key().as_bytes().to_vec());
@@ -223,9 +224,9 @@ impl MockBitcoinCore {
         }
     }
 
-    async fn create_transaction_with_many_inputs<A: PartialAddress + Send + Sync + 'static>(
+    async fn create_transaction_with_many_inputs(
         &self,
-        address: A,
+        address: Address,
         sat: u64,
         request_id: Option<H256>,
     ) -> Result<Transaction, BitcoinError> {
@@ -256,9 +257,9 @@ impl MockBitcoinCore {
         Ok(transaction)
     }
 
-    pub async fn send_to_address_with_many_outputs<A: PartialAddress + Send + Sync + 'static>(
+    pub async fn send_to_address_with_many_outputs(
         &self,
-        address: A,
+        address: Address,
         sat: u64,
         request_id: Option<H256>,
         fee_rate: SatPerVbyte,
@@ -281,9 +282,9 @@ impl MockBitcoinCore {
         Ok(transaction.txid())
     }
 
-    pub async fn create_transaction<A: PartialAddress + Send + Sync + 'static>(
+    pub async fn create_transaction(
         &self,
-        address: A,
+        address: Address,
         sat: u64,
         _fee_rate: SatPerVbyte, // ignored in this impl
         request_id: Option<H256>,
@@ -368,7 +369,7 @@ impl BitcoinCoreApi for MockBitcoinCore {
         Ok(block.header.block_hash())
     }
 
-    async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, BitcoinError> {
+    async fn get_new_address(&self) -> Result<Address, BitcoinError> {
         let bytes: [u8; 20] = (0..20)
             .map(|_| thread_rng().gen::<u8>())
             .collect::<Vec<_>>()
@@ -376,29 +377,22 @@ impl BitcoinCoreApi for MockBitcoinCore {
             .try_into()
             .unwrap();
         let address = BtcAddress::P2PKH(H160::from(bytes));
-        Ok(A::decode_str(&address.encode_str(Network::Regtest)?)?)
+        Ok(address.to_address(Network::Regtest)?)
     }
-    async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, BitcoinError> {
+    async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError> {
         let secp = Secp256k1::new();
         let raw_secret_key: [u8; SECRET_KEY_SIZE] = thread_rng().gen();
         let secret_key = SecretKey::from_slice(&raw_secret_key).unwrap();
-        let public_key = PublicKey::from_secret_key(&secp, &secret_key);
-        Ok(P::from(public_key.serialize()))
+        let public_key = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
+        Ok(PublicKey::new(public_key))
     }
-    fn dump_derivation_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(
-        &self,
-        public_key: P,
-    ) -> Result<PrivateKey, BitcoinError> {
+    fn dump_derivation_key(&self, public_key: &PublicKey) -> Result<PrivateKey, BitcoinError> {
         todo!()
     }
     fn import_derivation_key(&self, private_key: &PrivateKey) -> Result<(), BitcoinError> {
         todo!()
     }
-    async fn add_new_deposit_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(
-        &self,
-        _public_key: P,
-        _secret_key: Vec<u8>,
-    ) -> Result<(), BitcoinError> {
+    async fn add_new_deposit_key(&self, _public_key: PublicKey, _secret_key: Vec<u8>) -> Result<(), BitcoinError> {
         Ok(())
     }
     async fn get_best_block_hash(&self) -> Result<BlockHash, BitcoinError> {
@@ -457,9 +451,9 @@ impl BitcoinCoreApi for MockBitcoinCore {
             fee: None,
         })
     }
-    async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(
+    async fn create_and_send_transaction(
         &self,
-        address: A,
+        address: Address,
         sat: u64,
         fee_rate: SatPerVbyte,
         request_id: Option<H256>,
@@ -468,9 +462,9 @@ impl BitcoinCoreApi for MockBitcoinCore {
         let txid = self.send_transaction(&tx).await?;
         Ok(txid)
     }
-    async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(
+    async fn send_to_address(
         &self,
-        address: A,
+        address: Address,
         sat: u64,
         request_id: Option<H256>,
         fee_rate: SatPerVbyte,
@@ -493,22 +487,14 @@ impl BitcoinCoreApi for MockBitcoinCore {
         Ok(())
     }
 
-    async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync>(
-        &self,
-        addresses: Vec<A>,
-    ) -> Result<(), BitcoinError> {
+    async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError> {
         Ok(())
     }
     fn get_utxo_count(&self) -> Result<usize, BitcoinError> {
         Ok(0)
     }
 
-    async fn bump_fee<A: PartialAddress + Send + Sync + 'static>(
-        &self,
-        txid: &Txid,
-        address: A,
-        fee_rate: SatPerVbyte,
-    ) -> Result<Txid, BitcoinError> {
+    async fn bump_fee(&self, txid: &Txid, address: Address, fee_rate: SatPerVbyte) -> Result<Txid, BitcoinError> {
         unimplemented!()
     }
 

--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -4,7 +4,7 @@ mod bitcoin_simulator;
 
 use crate::{
     rpc::{IssuePallet, OraclePallet, SudoPallet, VaultRegistryPallet},
-    CurrencyId, FixedU128, H256Le, InterBtcParachain, InterBtcSigner, OracleKey, VaultId,
+    CurrencyId, FixedU128, H256Le, InterBtcParachain, InterBtcSigner, OracleKey, PartialAddress, VaultId,
 };
 use bitcoin::{BitcoinCoreApi, BlockHash, SatPerVbyte, Txid};
 use frame_support::assert_ok;
@@ -119,7 +119,7 @@ pub async fn assert_issue(
 
     let metadata = btc_rpc
         .send_to_address(
-            issue.vault_address,
+            issue.vault_address.to_address(btc_rpc.network()).unwrap(),
             (issue.amount + issue.fee) as u64,
             None,
             fee_rate,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod cli;
 
+mod addr;
 mod conn;
 mod error;
 mod retry;
@@ -22,6 +23,7 @@ use subxt::{
     subxt, Config,
 };
 
+pub use addr::PartialAddress;
 pub use error::{Error, SubxtError};
 pub use primitives::CurrencyInfo;
 pub use prometheus;

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -1,6 +1,6 @@
 use crate::{error::Error, metrics::update_bitcoin_metrics, system::VaultData, VaultIdManager};
 use bitcoin::{
-    BitcoinCoreApi, SatPerVbyte, Transaction, TransactionExt, TransactionMetadata, Txid,
+    BitcoinCoreApi, Error as BitcoinError, SatPerVbyte, Transaction, TransactionExt, TransactionMetadata, Txid,
     BLOCK_INTERVAL as BITCOIN_BLOCK_INTERVAL,
 };
 use futures::{
@@ -10,9 +10,9 @@ use futures::{
 };
 use runtime::{
     BtcAddress, BtcRelayPallet, Error as RuntimeError, FixedPointNumber, FixedU128, H256Le, InterBtcParachain,
-    InterBtcRedeemRequest, InterBtcRefundRequest, InterBtcReplaceRequest, IssuePallet, OraclePallet, PrettyPrint,
-    RedeemPallet, RedeemRequestStatus, RefundPallet, ReplacePallet, ReplaceRequestStatus, RequestRefundEvent,
-    SecurityPallet, UtilFuncs, VaultId, VaultRegistryPallet, H256,
+    InterBtcRedeemRequest, InterBtcRefundRequest, InterBtcReplaceRequest, IssuePallet, OraclePallet, PartialAddress,
+    PrettyPrint, RedeemPallet, RedeemRequestStatus, RefundPallet, ReplacePallet, ReplaceRequestStatus,
+    RequestRefundEvent, SecurityPallet, UtilFuncs, VaultId, VaultRegistryPallet, H256,
 };
 use service::{spawn_cancelable, ShutdownSender};
 use std::{collections::HashMap, convert::TryInto, time::Duration};
@@ -252,7 +252,14 @@ impl Request {
         tracing::debug!("Using fee_rate = {} sat/vByte", fee_rate.0);
 
         let txid = btc_rpc
-            .create_and_send_transaction(self.btc_address, self.amount as u64, fee_rate, Some(self.hash))
+            .create_and_send_transaction(
+                self.btc_address
+                    .to_address(btc_rpc.network())
+                    .map_err(BitcoinError::ConversionError)?,
+                self.amount as u64,
+                fee_rate,
+                Some(self.hash),
+            )
             .await?;
 
         self.wait_for_inclusion(parachain_rpc, btc_rpc, num_confirmations, txid, auto_rbf)
@@ -350,7 +357,16 @@ impl Request {
                     }
                     Either::Right((Some(Ok((old_fee, new_fee))), continuation)) => {
                         tracing::debug!("Attempting to bump fee rate from {} to {}...", old_fee.0, new_fee.0);
-                        match btc_rpc.bump_fee(&txid, self.btc_address, new_fee).await {
+                        match btc_rpc
+                            .bump_fee(
+                                &txid,
+                                self.btc_address
+                                    .to_address(btc_rpc.network())
+                                    .map_err(BitcoinError::ConversionError)?,
+                                new_fee,
+                            )
+                            .await
+                        {
                             Ok(new_txid) => {
                                 tracing::info!("Bumped fee rate. Old txid = {txid}, new txid = {new_txid}");
                                 txid = new_txid;
@@ -622,7 +638,7 @@ pub async fn execute_open_requests<B: BitcoinCoreApi + Clone + Send + Sync + 'st
 fn get_request_for_btc_tx(tx: &Transaction, hash_map: &HashMap<H256, Request>) -> Option<Request> {
     let hash = tx.get_op_return()?;
     let request = hash_map.get(&hash)?;
-    let paid_amount = tx.get_payment_amount_to(request.btc_address)?;
+    let paid_amount = tx.get_payment_amount_to(request.btc_address.to_payload().ok()?)?;
     if paid_amount as u128 >= request.amount {
         Some(request.clone())
     } else {
@@ -637,8 +653,8 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use bitcoin::{
-        json, Amount, Block, BlockHash, BlockHeader, Error as BitcoinError, Network, PartialAddress, PrivateKey,
-        Transaction, TransactionMetadata, Txid, PUBLIC_KEY_SIZE,
+        json, Address, Amount, Block, BlockHash, BlockHeader, Error as BitcoinError, Network, PrivateKey, PublicKey,
+        Transaction, TransactionMetadata, Txid,
     };
     use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
@@ -782,26 +798,26 @@ mod tests {
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, BitcoinError>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
             async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
-            async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, BitcoinError>;
-            async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, BitcoinError>;
-            fn dump_derivation_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(&self, public_key: P) -> Result<PrivateKey, BitcoinError>;
+            async fn get_new_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError>;
+            fn dump_derivation_key(&self, public_key: &PublicKey) -> Result<PrivateKey, BitcoinError>;
             fn import_derivation_key(&self, private_key: &PrivateKey) -> Result<(), BitcoinError>;
-            async fn add_new_deposit_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(&self, public_key: P, secret_key: Vec<u8>) -> Result<(), BitcoinError>;
+            async fn add_new_deposit_key(&self, public_key: PublicKey, secret_key: Vec<u8>) -> Result<(), BitcoinError>;
             async fn get_best_block_hash(&self) -> Result<BlockHash, BitcoinError>;
             async fn get_block(&self, hash: &BlockHash) -> Result<Block, BitcoinError>;
             async fn get_block_header(&self, hash: &BlockHash) -> Result<BlockHeader, BitcoinError>;
             async fn get_mempool_transactions<'a>(&'a self) -> Result<Box<dyn Iterator<Item = Result<Transaction, BitcoinError>> + Send + 'a>, BitcoinError>;
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
-            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
+            async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
+            async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
-            async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync + 'static>(&self, addresses: Vec<A>) -> Result<(), BitcoinError>;
+            async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
-            async fn bump_fee<A: PartialAddress + Send + Sync + 'static>(
+            async fn bump_fee(
                 &self,
                 txid: &Txid,
-                address: A,
+                address: Address,
                 fee_rate: SatPerVbyte,
             ) -> Result<Txid, BitcoinError>;
             fn is_in_mempool(&self, txid: Txid) -> Result<bool, BitcoinError>;
@@ -894,12 +910,14 @@ mod tests {
 
             let mut btc_rpc = MockBitcoin::default();
 
+            btc_rpc.expect_network().returning(|| Network::Regtest);
+
             btc_rpc
                 .expect_get_block_count()
                 .returning(move || Ok(current_bitcoin_height as u64));
 
             btc_rpc
-                .expect_create_and_send_transaction::<BtcAddress>()
+                .expect_create_and_send_transaction()
                 .returning(|_, _, _, _| Ok(Txid::default()));
 
             btc_rpc.expect_wait_for_transaction_metadata().returning(|_, _| {
@@ -1032,8 +1050,10 @@ mod tests {
 
         let mut btc_rpc = MockBitcoin::default();
 
+        btc_rpc.expect_network().returning(|| Network::Regtest);
+
         btc_rpc
-            .expect_create_and_send_transaction::<BtcAddress>()
+            .expect_create_and_send_transaction()
             .returning(|_, _, _, _| Ok(Txid::default()));
 
         btc_rpc.expect_wait_for_transaction_metadata().returning(|_, _| {

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -1,11 +1,11 @@
 use crate::{
     delay::RandomDelay, metrics::publish_expected_bitcoin_balance, Error, Event, IssueRequests, VaultIdManager,
 };
-use bitcoin::{BitcoinCoreApi, BlockHash, Transaction, TransactionExt};
+use bitcoin::{BitcoinCoreApi, BlockHash, Error as BitcoinError, PublicKey, Transaction, TransactionExt};
 use futures::{channel::mpsc::Sender, future, SinkExt, StreamExt, TryFutureExt};
 use runtime::{
     BtcAddress, BtcPublicKey, BtcRelayPallet, CancelIssueEvent, ExecuteIssueEvent, H256Le, InterBtcParachain,
-    IssuePallet, IssueRequestStatus, PrettyPrint, RequestIssueEvent, UtilFuncs, VaultId, H256,
+    IssuePallet, IssueRequestStatus, PartialAddress, PrettyPrint, RequestIssueEvent, UtilFuncs, VaultId, H256,
 };
 use service::Error as ServiceError;
 use sha2::{Digest, Sha256};
@@ -125,7 +125,7 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
                     .into_iter()
                     .filter_map(|(_, request)| {
                         if (request.btc_height as usize) < btc_pruned_start_height {
-                            Some(request.btc_address)
+                            Some(request.btc_address.to_address(bitcoin_core.network()).ok()?)
                         } else {
                             None
                         }
@@ -155,15 +155,24 @@ async fn process_transaction_and_execute_issue<B: BitcoinCoreApi + Clone + Send 
     transaction: Transaction,
     random_delay: Arc<Box<dyn RandomDelay + Send + Sync>>,
 ) -> Result<(), Error> {
-    let addresses = transaction.extract_output_addresses::<BtcAddress>();
+    let addresses: Vec<BtcAddress> = transaction
+        .extract_output_addresses()
+        .into_iter()
+        .filter_map(|payload| BtcAddress::from_payload(payload).ok())
+        .collect();
     let mut issue_requests = issue_set.lock().await;
     if let Some((issue_id, address)) = addresses.iter().find_map(|address| {
         let issue_id = issue_requests.get_key_for_value(address)?;
         Some((*issue_id, *address))
     }) {
         let issue = btc_parachain.get_issue_request(issue_id).await?;
+        let payload = if let Ok(payload) = address.to_payload() {
+            payload
+        } else {
+            return Ok(());
+        };
         // tx has output to address
-        match transaction.get_payment_amount_to(address) {
+        match transaction.get_payment_amount_to(payload) {
             None => {
                 // this should never happen, so use WARN
                 tracing::warn!(
@@ -247,8 +256,12 @@ async fn add_new_deposit_key<B: BitcoinCoreApi + Clone + Send + Sync + 'static>(
     hasher.input(public_key.0);
     // input issue id
     hasher.input(secure_id.as_bytes());
+
     bitcoin_core
-        .add_new_deposit_key(public_key.0, hasher.result().as_slice().to_vec())
+        .add_new_deposit_key(
+            PublicKey::from_slice(&public_key.0).map_err(BitcoinError::KeyError)?,
+            hasher.result().as_slice().to_vec(),
+        )
         .await?;
     Ok(())
 }

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -707,8 +707,8 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use bitcoin::{
-        json, Amount, Block, BlockHash, BlockHeader, Error as BitcoinError, Network, PartialAddress, PrivateKey,
-        SatPerVbyte, Transaction, TransactionMetadata, Txid, PUBLIC_KEY_SIZE,
+        json, Address, Amount, Block, BlockHash, BlockHeader, Error as BitcoinError, Network, PrivateKey, PublicKey,
+        SatPerVbyte, Transaction, TransactionMetadata, Txid,
     };
     use jsonrpc_core::serde_json::{Map, Value};
     use runtime::{
@@ -834,26 +834,26 @@ mod tests {
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, BitcoinError>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
             async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
-            async fn get_new_address<A: PartialAddress + Send + 'static>(&self) -> Result<A, BitcoinError>;
-            async fn get_new_public_key<P: From<[u8; PUBLIC_KEY_SIZE]> + 'static>(&self) -> Result<P, BitcoinError>;
-            fn dump_derivation_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(&self, public_key: P) -> Result<PrivateKey, BitcoinError>;
+            async fn get_new_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError>;
+            fn dump_derivation_key(&self, public_key: &PublicKey) -> Result<PrivateKey, BitcoinError>;
             fn import_derivation_key(&self, private_key: &PrivateKey) -> Result<(), BitcoinError>;
-            async fn add_new_deposit_key<P: Into<[u8; PUBLIC_KEY_SIZE]> + Send + Sync + 'static>(&self, public_key: P, secret_key: Vec<u8>) -> Result<(), BitcoinError>;
+            async fn add_new_deposit_key(&self, public_key: PublicKey, secret_key: Vec<u8>) -> Result<(), BitcoinError>;
             async fn get_best_block_hash(&self) -> Result<BlockHash, BitcoinError>;
             async fn get_block(&self, hash: &BlockHash) -> Result<Block, BitcoinError>;
             async fn get_block_header(&self, hash: &BlockHash) -> Result<BlockHeader, BitcoinError>;
             async fn get_mempool_transactions<'a>(&'a self) -> Result<Box<dyn Iterator<Item = Result<Transaction, BitcoinError>> + Send + 'a>, BitcoinError>;
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn create_and_send_transaction<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
-            async fn send_to_address<A: PartialAddress + Send + Sync + 'static>(&self, address: A, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
+            async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
+            async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
-            async fn rescan_electrs_for_addresses<A: PartialAddress + Send + Sync + 'static>(&self, addresses: Vec<A>) -> Result<(), BitcoinError>;
+            async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;
             fn get_utxo_count(&self) -> Result<usize, BitcoinError>;
-            async fn bump_fee<A: PartialAddress + Send + Sync + 'static>(
+            async fn bump_fee(
                 &self,
                 txid: &Txid,
-                address: A,
+                address: Address,
                 fee_rate: SatPerVbyte,
             ) -> Result<Txid, BitcoinError>;
             fn is_in_mempool(&self, txid: Txid) -> Result<bool, BitcoinError>;

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -8,7 +8,7 @@ use crate::{
     Event, IssueRequests, CHAIN_HEIGHT_POLLING_INTERVAL,
 };
 use async_trait::async_trait;
-use bitcoin::{BitcoinCore, BitcoinCoreApi, Error as BitcoinError};
+use bitcoin::{BitcoinCore, BitcoinCoreApi, Error as BitcoinError, PublicKey};
 use clap::Parser;
 use futures::{
     channel::{mpsc, mpsc::Sender},
@@ -227,17 +227,18 @@ impl<BCA: BitcoinCoreApi + Clone + Send + Sync + 'static> VaultIdManager<BCA> {
             .btc_parachain
             .get_public_key()
             .await?
-            .ok_or(bitcoin::Error::MissingPublicKey)?;
+            .ok_or(BitcoinError::MissingPublicKey)?;
 
         // migration to the new shared public key setup: copy the public key from the
         // currency-specific wallet to the master wallet. This can be removed once all
         // vaults have migrated
-        if let Ok(private_key) = btc_rpc.dump_derivation_key(derivation_key.0) {
+        let public_key = PublicKey::from_slice(&derivation_key.0).map_err(BitcoinError::KeyError)?;
+        if let Ok(private_key) = btc_rpc.dump_derivation_key(&public_key) {
             self.btc_rpc_master_wallet.import_derivation_key(&private_key)?;
         }
 
         // Copy the derivation key from the master wallet to use currency-specific wallet
-        match self.btc_rpc_master_wallet.dump_derivation_key(derivation_key.0) {
+        match self.btc_rpc_master_wallet.dump_derivation_key(&public_key) {
             Ok(private_key) => {
                 btc_rpc.import_derivation_key(&private_key)?;
             }
@@ -755,8 +756,10 @@ impl VaultService {
 
         if self.btc_parachain.get_public_key().await?.is_none() {
             tracing::info!("Registering bitcoin public key to the parachain...");
-            let new_key = self.btc_rpc_master_wallet.get_new_public_key().await?;
-            self.btc_parachain.register_public_key(new_key).await?;
+            let public_key = self.btc_rpc_master_wallet.get_new_public_key().await?;
+            self.btc_parachain
+                .register_public_key(public_key.key.serialize().into())
+                .await?;
         }
 
         Ok(())


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Removes generics on `BitcoinCoreApi` trait methods to allow for dynamic dispatch - a prerequisite for merging #349 to support using alternate implementations at runtime. Has the added advantage of being able to remove the `interbtc-bitcoin` dependency from the `bitcoin` crate.