### PR TITLE
fix: don't abort on rescan timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9749,7 +9749,7 @@ dependencies = [
  "signal-hook-tokio",
  "sp-core 6.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "subxt 0.23.0",
- "sysinfo 0.25.3",
+ "sysinfo 0.25.1",
  "tempdir",
  "thiserror",
  "tokio",
@@ -13036,9 +13036,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.25.3"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71eb43e528fdc239f08717ec2a378fdb017dddbc3412de15fff527554591a66c"
+checksum = "373e4bc9213f734126e2be3e2e118dbc9b909c37487d8d755822bc90f70ae62a"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -13051,9 +13051,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621609553b14bca49448b3c97e625d7187980cc2a42fd169b4c3b306dcc4a7e9"
+checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -14033,7 +14033,7 @@ dependencies = [
  "sp-arithmetic 5.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-core 6.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",
  "sp-keyring",
- "sysinfo 0.26.1",
+ "sysinfo 0.26.2",
  "thiserror",
  "tokio",
  "tokio-metrics",

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -7,7 +7,7 @@ mod iter;
 
 use async_trait::async_trait;
 use backoff::{backoff::Backoff, future::retry, ExponentialBackoff};
-use bitcoincore_rpc::bitcoin::consensus::encode::serialize_hex;
+use bitcoincore_rpc::{bitcoin::consensus::encode::serialize_hex, bitcoincore_rpc_json::ScanningDetails};
 pub use bitcoincore_rpc::{
     bitcoin::{
         blockdata::{opcodes::all as opcodes, script::Builder},
@@ -54,6 +54,9 @@ const NOT_IN_MEMPOOL_ERROR_CODE: i32 = BitcoinRpcError::RpcInvalidAddressOrKey a
 
 // Time to sleep before retry on startup.
 const RETRY_DURATION: Duration = Duration::from_millis(1000);
+
+// Time to sleep before checking if the rescan is done yet.
+const RESCAN_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 // The default initial interval value (1 second).
 const INITIAL_INTERVAL: Duration = Duration::from_millis(1000);
@@ -544,6 +547,19 @@ impl BitcoinCore {
         self.with_wallet(|| async { Ok(self.rpc.import_private_key(&privkey, None, None)?) })
             .await
     }
+
+    pub async fn wait_for_rescan(&self) -> Result<(), Error> {
+        loop {
+            let wallet_info = self.rpc.get_wallet_info()?;
+            match wallet_info.scanning {
+                Some(ScanningDetails::Scanning { progress, .. }) => {
+                    info!("Scanning progress: {progress}");
+                    tokio::time::sleep(RESCAN_POLL_INTERVAL).await;
+                }
+                _ => return Ok(()),
+            }
+        }
+    }
 }
 
 /// true if the given indicates that the item was not found in the mempool
@@ -894,8 +910,24 @@ impl BitcoinCoreApi for BitcoinCore {
     }
 
     async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error> {
-        self.rpc.rescan_blockchain(Some(start_height), Some(end_height))?;
-        Ok(())
+        // if there happens to be a rescan going on, we wait for it to finish and then
+        // initiate our own rescan, since the range might be different and keys might just
+        // have been imported
+        self.wait_for_rescan().await?;
+
+        match self
+            .rpc
+            .rescan_blockchain(Some(start_height), Some(end_height))
+            .map(|_| ())
+            .map_err(Into::<Error>::into)
+        {
+            Err(e) if e.is_transport_error() => {
+                // we assume that if we get a transport error, it's because the
+                // rescan timed out. We just wait for it to complete
+                self.wait_for_rescan().await
+            }
+            x => x,
+        }
     }
 
     async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), Error> {

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -11,10 +11,6 @@ use service::Error as ServiceError;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
-// we have seen scanning rates as low as 61 blocks/s. Process 100 blocks per time so that we
-// don't run into the 15 s timeout.
-const SCAN_CHUNK_SIZE: usize = 100;
-
 // initialize `issue_set` with currently open issues, and return the block height
 // from which to start watching the bitcoin chain
 pub(crate) async fn initialize_issue_set<B: BitcoinCoreApi + Clone + Send + Sync + 'static>(
@@ -110,10 +106,9 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
 
     // in parallel, rescan what blockchain we do have stored locally
     tracing::info!("Rescanning bitcoin chain from height {}...", rescan_start_height);
-    for (range_start, range_end) in chunks(rescan_start_height, btc_end_height) {
-        tracing::debug!("Scanning chain blocks {range_start}-{range_end}...");
-        bitcoin_core.rescan_blockchain(range_start, range_end).await?;
-    }
+    bitcoin_core
+        .rescan_blockchain(rescan_start_height, btc_end_height)
+        .await?;
 
     // also check in electrs in case there were any requests from before the pruned height
     if btc_start_height < btc_pruned_start_height {
@@ -139,13 +134,6 @@ pub async fn add_keys_from_past_issue_request<B: BitcoinCoreApi + Clone + Send +
     }
 
     Ok(())
-}
-
-/// Return the chunks of size SCAN_CHUNK_SIZE from first..last (including).
-fn chunks(first: usize, last: usize) -> impl Iterator<Item = (usize, usize)> {
-    (first..last)
-        .step_by(SCAN_CHUNK_SIZE)
-        .map(move |x| (x, usize::min(x + SCAN_CHUNK_SIZE - 1, last)))
 }
 
 /// execute issue requests with a matching Bitcoin payment
@@ -383,15 +371,4 @@ pub async fn listen_for_issue_cancels(
         )
         .await?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_chunks() {
-        let result: Vec<_> = chunks(50, 316).collect();
-        assert_eq!(result, vec![(50, 149), (150, 249), (250, 316)]);
-    }
 }


### PR DESCRIPTION
I was trying the approach where upon timeout, we would abort the rescan and decrease the chunk size. However, it turns out that calling abortrescan shortly followed by a rescanblockchain will almost always fail. Anyway, I found a different solution: to check the rescan status in [getwalletinfo](https://developer.bitcoin.org/reference/rpc/getwalletinfo.html) when we get a timeout. It's not 100% foolproof, since we could have transport errors for other reasons, so the rescan might not have been initiated correctly. But it's the best solution I've found so far 