### PR TITLE
refactor: don't use block_on

### DIFF
--- a/vault/src/main.rs
+++ b/vault/src/main.rs
@@ -45,7 +45,7 @@ async fn catch_signals<F>(mut shutdown_signals: Signals, future: F) -> Result<()
 where
     F: Future<Output = Result<(), Error>> + Send + 'static,
 {
-    let blocking_task = tokio::task::spawn_blocking(|| futures::executor::block_on(future));
+    let blocking_task = tokio::task::spawn_blocking(|| future);
     tokio::select! {
         res = blocking_task => {
             let _ = res?;


### PR DESCRIPTION
`block_on` has this documentation: `Run a future to completion on the current thread.`. We want the tasks to use the thread pool, rather than to run on a single thread. Also it's just cleaner