### PR TITLE
feat(runner): CLI for client type, Readme update

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -3,7 +3,7 @@ name = "runner"
 version = "0.0.1"
 authors = ["Interlay <contact@interlay.io>"]
 edition = "2018"
-description = "The Runner runs and auto-updates Vault clients across multiple networks (Interlay, Kintsugi, testnets)."
+description = "The Runner runs and auto-updates interbtc clients (vault, oracle, faucet) across multiple networks (Interlay, Kintsugi, testnets)."
 
 [dependencies]
 clap = { version = "3.1", features = ["derive"]}

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,42 +1,52 @@
 # Runner
 
-Auto-updater software for the vault client. The Runner runs and auto-updates Vault clients across multiple networks (Interlay, Kintsugi,
-testnets).
+Auto-updater software for interbtc clients (vault, oracle, faucet). The Runner runs and auto-updates clients across multiple networks (Interlay, Kintsugi,
+testnets), by reading on-chan release data (`ClientsInfo::CurrentClientsRelease` storage map).
 
 > **IMPORTANT**
 > 
-> It is CRITICAL that the runner is shut down gracefully, otherwise the spawned vault process will keep running. If there are multiple running vault executables for the same [Vault ID(s)](https://docs.interlay.io/#/vault/overview?id=multi-collateral-system), redeem requests will be fulfilled by all vault executables, leading to double-spending the BTC in the vault's wallet! The Vault operator will need to provide its own BTC to cover for the loss, to avoid having its [collateral slashed](https://docs.interlay.io/#/guides/bridge?id=_4-optional-retry-or-reimburse-your-request).
+> It is CRITICAL that the runner is shut down gracefully, otherwise the spawned client process will keep running. If there are multiple running vault executables for the same [Vault ID(s)](https://docs.interlay.io/#/vault/overview?id=multi-collateral-system), redeem requests will be fulfilled by all vault executables, leading to double-spending the BTC in the vault's wallet! The Vault operator will need to provide its own BTC to cover for the loss, to avoid having its [collateral slashed](https://docs.interlay.io/#/guides/bridge?id=_4-optional-retry-or-reimburse-your-request).
 > 
 > Supported process signals for graceful termination: `SIGHUP`, `SIGTERM`, `SIGINT`, `SIGQUIT`.
 
 
 ```bash
 USAGE:
-    runner [OPTIONS] --parachain-ws <PARACHAIN_WS> [VAULT_ARGS]...
+    runner [OPTIONS] --parachain-ws <PARACHAIN_WS> [CLIENT_ARGS]...
 
 ARGS:
-    <VAULT_ARGS>...    CLI arguments to pass to the vault executable
+    <CLIENT_ARGS>...    CLI arguments to pass to the client executable
 
 OPTIONS:
-        --download-path <DOWNLOAD_PATH>    Download path for the vault executable [default: .]
-    -h, --help                             Print help information
-        --parachain-ws <PARACHAIN_WS>      Parachain websocket URL
-    -V, --version                          Print version information
+        --client-type <CLIENT_TYPE>
+            Client to run, one of: vault, oracle, faucet. Default is `vault` [default: vault]
+
+        --download-path <DOWNLOAD_PATH>
+            Download path for the client executable [default: .]
+
+    -h, --help
+            Print help information
+
+        --parachain-ws <PARACHAIN_WS>
+            Parachain websocket URL
+
+    -V, --version
+            Print version information
 ```
 
 ## Run
-Pass the CLI vault arguments as positional arguments (preceeded by double dashes: `--`), after passing the command options of the `runner` executable. Example:
+Pass the CLI client arguments as positional arguments (preceeded by double dashes: `--`), after passing the command options of the `runner` executable. Example:
 ```bash
-./runner --parachain-ws 'ws://localhost:9944' --download-path=./runner_tmp_dir -- --bitcoin-rpc-url 'http://localhost:18443' --bitcoin-rpc-user rpcuser --bitcoin-rpc-pass rpcpassword --keyfile keyfile.json --keyname 0xa81f76187f1e5d2059f67439c4242a92a5cd66a409579db73f156c6e2aae5102 --faucet-url 'http://localhost:3033' --auto-register=KSM=faucet --btc-parachain-url 'ws://localhost:9944'
+./runner --client-type vault --parachain-ws 'ws://localhost:9944' --download-path=./runner_tmp_dir -- --bitcoin-rpc-url 'http://localhost:18443' --bitcoin-rpc-user rpcuser --bitcoin-rpc-pass rpcpassword --keyfile keyfile.json --keyname 0xa81f76187f1e5d2059f67439c4242a92a5cd66a409579db73f156c6e2aae5102 --faucet-url 'http://localhost:3033' --auto-register=KSM=faucet --btc-parachain-url 'ws://localhost:9944'
 ```
 
 ## How it works
-The runner queries raw parachain storage every `BLOCK_TIME` seconds (see `runner.rs`). It does so using the `state_getStorage` RPC call and manually performs the SCALE decoding, to avoid relying on dependencies that require maintenance (such as `subxt`). 
+The runner queries raw parachain storage every `BLOCK_TIME` seconds (see `runner.rs`). It does so using [subxt](https://github.com/paritytech/subxt) dynamic queries with manual SCALE decoding, to avoid maintaining chain metadata for the runner. 
 
 Two assumptions hardcoded into the runner that might change, are:
-- The release is found under `VaultRegistry::CurrentClientRelease` - used for computing the storage key.
+- The release is found under `ClientsInfo::CurrentClientsRelease`
 - The data type of the release is [this struct](https://github.com/interlay/interbtc-clients/blob/b74d1c0c1426f0b481cf90b9a783df69fe54a614/runner/src/runner.rs#L73).
 
 When a new release URL is found, the executable is downloaded and spawned as a child process of the runner. The previously running executable is killed using `SIGTERM` and removed from the file system.
 
-The runner needs to be terminated gracefully in order to clean up its child process (the vault). Otherwise, multiple running vault executables will double-spend redeem requests from the vault's BTC wallet.
+The runner needs to be terminated gracefully in order to clean up its child process. Otherwise, multiple running vault executables will double-spend redeem requests from their BTC wallet.

--- a/runner/src/error.rs
+++ b/runner/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
     ChildProcessExists,
     #[error("Failed to terminate child process")]
     ProcessTerminationFailure,
+    #[error("Failed to parse the client-type CLI argument")]
+    ClientTypeParsingError,
 }
 
 impl<E: Into<Error> + Sized> From<BackoffError<E>> for Error {

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use error::Error;
 
 use futures::{FutureExt, TryFutureExt};
+use runner::ClientType;
 use signal_hook::consts::*;
 use signal_hook_tokio::Signals;
 use std::{fmt::Debug, path::PathBuf};
@@ -15,16 +16,20 @@ use crate::runner::{retry_with_log_async, subxt_api, Runner};
 #[derive(Parser, Debug, Clone)]
 #[clap(version, author, about, trailing_var_arg = true)]
 pub struct Opts {
+    /// Client to run, one of: vault, oracle, faucet. Default is `vault`.
+    #[clap(long, default_value = "vault")]
+    pub client_type: ClientType,
+
     /// Parachain websocket URL.
     #[clap(long)]
     pub parachain_ws: String,
 
-    /// Download path for the vault executable.
+    /// Download path for the client executable.
     #[clap(long, default_value = ".")]
     pub download_path: PathBuf,
 
-    /// CLI arguments to pass to the vault executable.
-    pub vault_args: Vec<String>,
+    /// CLI arguments to pass to the client executable.
+    pub client_args: Vec<String>,
 }
 
 #[tokio::main]


### PR DESCRIPTION
Adds `client-type` CLI argument to the runner and updates the readme / comments.

I'm not sure whether using an `enum` that implements `FromStr` and `Display` is the cleanest approach, let me know what you think.