### PR TITLE
feat(runner): don't re-download if checksums match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9745,6 +9745,7 @@ dependencies = [
  "nix",
  "parity-scale-codec",
  "reqwest",
+ "sha2 0.8.2",
  "signal-hook",
  "signal-hook-tokio",
  "sp-core 6.0.0 (git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.24)",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -25,6 +25,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 futures = "0.3.21"
 backoff = { version = "0.3.0", features = ["tokio"] }
 subxt = "0.23.0"
+sha2 = "0.8.2"
 
 [dev-dependencies]
 sysinfo = "0.25.1"

--- a/runner/src/runner.rs
+++ b/runner/src/runner.rs
@@ -132,12 +132,20 @@ impl Runner {
     fn try_load_downloaded_binary(runner: &mut impl RunnerExt) -> Result<(), Error> {
         let (bin_name, bin_path) = runner.get_bin_path()?;
         let file_content = fs::read(bin_path.clone()).map_err(|_| Error::NoDownloadedRelease)?;
+        let checksum = H256::from_slice(&sha256sum(&file_content));
         let downloaded_release = DownloadedRelease {
-            checksum: H256::from_slice(&sha256sum(&file_content)),
-            path: bin_path,
+            checksum,
+            path: bin_path.clone(),
             bin_name,
         };
         runner.set_downloaded_release(Some(downloaded_release));
+        if let Ok(stringified_path) = bin_path.into_os_string().into_string() {
+            log::info!(
+                "Loaded binary from disk, at {}, with checksum {:#x}",
+                stringified_path,
+                checksum
+            );
+        }
         Ok(())
     }
 

--- a/runner/src/runner.rs
+++ b/runner/src/runner.rs
@@ -102,7 +102,6 @@ pub struct DownloadedRelease {
 
 fn sha256sum(bytes: &[u8]) -> Vec<u8> {
     let mut hasher = Sha256::default();
-    // input compressed public key
     hasher.input(bytes);
     hasher.result().as_slice().to_vec()
 }


### PR DESCRIPTION
Uses checksum of the release to check if re-downloading can be avoided. Validation of the downloaded binary will be done in an upcoming PR.