### PR TITLE
refactor: remove network flag from cli

### DIFF
--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -14,6 +14,7 @@ use std::{io::Error as IoError, num::TryFromIntError, string::FromUtf8Error};
 use thiserror::Error;
 use tokio::time::error::Elapsed;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
 pub enum KeyLoadingError {
     #[error("IoError: {0}")]

--- a/bitcoin/src/light/mod.rs
+++ b/bitcoin/src/light/mod.rs
@@ -15,7 +15,6 @@ const RETRY_DURATION: Duration = Duration::from_millis(1000);
 
 #[derive(Clone)]
 pub struct BitcoinLight {
-    network: Network,
     private_key: PrivateKey,
     secp_ctx: secp256k1::Secp256k1<secp256k1::All>,
     electrs: ElectrsClient,
@@ -24,10 +23,10 @@ pub struct BitcoinLight {
 }
 
 impl BitcoinLight {
-    pub fn new(electrs_url: Option<String>, network: Network, private_key: PrivateKey) -> Result<Self, Error> {
+    pub fn new(electrs_url: Option<String>, private_key: PrivateKey) -> Result<Self, Error> {
+        let network = private_key.network;
         let electrs_client = ElectrsClient::new(electrs_url, network)?;
         Ok(Self {
-            network,
             private_key,
             secp_ctx: secp256k1::Secp256k1::new(),
             electrs: electrs_client.clone(),
@@ -77,7 +76,7 @@ impl BitcoinLight {
 #[async_trait]
 impl BitcoinCoreApi for BitcoinLight {
     fn network(&self) -> Network {
-        self.network
+        self.private_key.network
     }
 
     async fn wait_for_block(&self, height: u32, num_confirmations: u32) -> Result<Block, BitcoinError> {

--- a/bitcoin/src/light/wallet.rs
+++ b/bitcoin/src/light/wallet.rs
@@ -209,7 +209,7 @@ impl Wallet {
         let address = Address::from_script(script_pubkey, self.network).ok_or(Error::InvalidAddress)?;
         let key_store = self.key_store.read()?;
         let private_key = key_store.get(&address).ok_or(Error::NoPrivateKey)?;
-        Ok(private_key.clone())
+        Ok(*private_key)
     }
 
     pub fn get_pub_key(&self, script_pubkey: &Script) -> Result<PublicKey, Error> {
@@ -296,7 +296,7 @@ impl Wallet {
                     }
 
                     // https://github.com/bitcoin/bitcoin/blob/01e1627e25bc5477c40f51da03c3c31b609a85c9/src/wallet/spend.cpp#L945
-                    let n_bytes = calculate_maximum_signed_tx_size(&psbt, &self);
+                    let n_bytes = calculate_maximum_signed_tx_size(&psbt, self);
                     let fee_needed = m_effective_feerate.get_fee(n_bytes);
                     let n_fee_ret = select_coins.get_selected_value() - recipients_sum - change_amount;
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -117,7 +117,7 @@ impl<Config: Clone + Send + 'static, S: Service<Config>, F: Fn()> ConnectionMana
                         .map(|i| i.symbol().to_string())
                         .unwrap_or_default(),
                 );
-                Ok(config_copy.new_client_with_network(Some(wallet_name), network_copy)?)
+                config_copy.new_client_with_network(Some(wallet_name), network_copy)
             };
 
             let service = S::new_service(


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Already included in the `PrivateKey` so there is no need to require it separately.