### PR TITLE
fix: correct bitcoin walletname for foreign currencies

### DIFF
--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -72,6 +72,8 @@ pub enum Error {
     ArithmeticError,
     #[error("MissingBitcoinFeeInfo")]
     MissingBitcoinFeeInfo,
+    #[error("FailedToConstructWalletName")]
+    FailedToConstructWalletName,
 }
 
 impl Error {


### PR DESCRIPTION
Resolves #382.

- use correct symbol for foreign currencies
- when `symbol` returns an error, propagate an error rather than silently using a default