### PR TITLE
feat: update foreign assets dynamically

### DIFF
--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -43,6 +43,10 @@ mod metadata_aliases {
     pub type InterBtcRichBlockHeader = metadata::runtime_types::btc_relay::types::RichBlockHeader<BlockNumber>;
     pub type BitcoinBlockHeight = u32;
 
+    pub use metadata::asset_registry::events::{
+        RegisteredAsset as RegisteredAssetEvent, UpdatedAsset as UpdatedAssetEvent,
+    };
+
     pub use metadata::oracle::events::FeedValues as FeedValuesEvent;
 
     pub use metadata::issue::events::{

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -586,11 +586,18 @@ impl VaultService {
         let (issue_event_tx, issue_event_rx) = mpsc::channel::<Event>(32);
         let (replace_event_tx, replace_event_rx) = mpsc::channel::<Event>(16);
 
+        let listen_for_registered_assets =
+            |rpc: InterBtcParachain| async move { rpc.listen_for_registered_assets().await };
+
         let listen_for_fee_rate_estimate_changes =
             |rpc: InterBtcParachain| async move { rpc.listen_for_fee_rate_changes().await };
 
         tracing::info!("Starting all services...");
         let tasks = vec![
+            (
+                "Registered Asset Listener",
+                run(listen_for_registered_assets(self.btc_parachain.clone())),
+            ),
             (
                 "Fee Estimate Listener",
                 run(listen_for_fee_rate_estimate_changes(self.btc_parachain.clone())),


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

With the global asset registry cache, Vaults would have to restart to refresh which may not be possible (for example our lib integration tests) so we should listen for select `asset-registry` events and dynamically update this.