### PR TITLE
fix: actually detect incorrect bitcoin network

### DIFF
--- a/bitcoin/src/light/mod.rs
+++ b/bitcoin/src/light/mod.rs
@@ -25,6 +25,7 @@ pub struct BitcoinLight {
 impl BitcoinLight {
     pub fn new(electrs_url: Option<String>, private_key: PrivateKey) -> Result<Self, Error> {
         let network = private_key.network;
+        log::info!("Using network: {}", network);
         let electrs_client = ElectrsClient::new(electrs_url, network)?;
         Ok(Self {
             private_key,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

I think we expected the serialization of `Network::Bitcoin` to be `mainnet` which is not the case so this check was previously superfluous when using mainnet against a testnet parachain.

On a side note, because we removed the checks in service to always restart on any error we will be stuck in a loop now if the wrong Bitcoin network is configured. We should distinguish between recoverable and unrecoverable errors for which this is the latter.