### PR TITLE
fix: runner: use binary name from url

### DIFF
--- a/runner/src/error.rs
+++ b/runner/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     ProcessTerminationFailure,
     #[error("Failed to parse the client-type CLI argument")]
     ClientTypeParsingError,
+    #[error("Failed to derive the release name of the vault")]
+    ClientNameDerivationError,
 }
 
 impl<E: Into<Error> + Sized> From<BackoffError<E>> for Error {


### PR DESCRIPTION
As discussed on discord. With this change, people no longer need to run binaries from different folders