### PR TITLE
refactor: allow service to abort on some errors

### DIFF
--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Error> {
                     Ok(())
                 })
                 .await?;
-            Ok(())
+            Ok::<_, Error>(())
         });
 
         let http_server = on_shutdown(shutdown_tx.clone(), async move {

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -1,5 +1,4 @@
 use bitcoin::Error as BitcoinError;
-use hyper::{http::Error as HyperHttpError, Error as HyperError};
 use runtime::Error as RuntimeError;
 use serde_json::Error as SerdeJsonError;
 use std::{io::Error as IoError, num::ParseIntError};
@@ -7,9 +6,12 @@ use thiserror::Error;
 use tokio::task::JoinError as TokioJoinError;
 
 #[derive(Error, Debug)]
-pub enum Error {
-    #[error("Received an invalid response")]
-    InvalidResponse,
+pub enum Error<InnerError> {
+    #[error("Abort: {0}")]
+    Abort(InnerError),
+    #[error("Retry: {0}")]
+    Retry(InnerError),
+
     #[error("Client has shutdown")]
     ClientShutdown,
     #[error("OsString parsing error")]
@@ -23,13 +25,8 @@ pub enum Error {
 
     #[error("SerdeJsonError: {0}")]
     SerdeJsonError(#[from] SerdeJsonError),
-    #[error("HyperError: {0}")]
-    HyperError(#[from] HyperError),
-    #[error("HyperHttpError: {0}")]
-    HyperHttpError(#[from] HyperHttpError),
     #[error("ParseIntError: {0}")]
     ParseIntError(#[from] ParseIntError),
-
     #[error("RuntimeError: {0}")]
     RuntimeError(#[from] RuntimeError),
     #[error("BitcoinError: {0}")]
@@ -38,8 +35,4 @@ pub enum Error {
     TokioError(#[from] TokioJoinError),
     #[error("System I/O error: {0}")]
     IoError(#[from] IoError),
-
-    /// Other error
-    #[error("Other: {0}")]
-    Other(String),
 }

--- a/vault/src/error.rs
+++ b/vault/src/error.rs
@@ -1,9 +1,7 @@
 use bitcoin::Error as BitcoinError;
-use hex::FromHexError;
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
-use runtime::{Error as RuntimeError, SubxtError};
-use service::Error as ServiceError;
+use runtime::Error as RuntimeError;
 use thiserror::Error;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
@@ -24,20 +22,20 @@ pub enum Error {
     #[error("Faucet url not set")]
     FaucetUrlNotSet,
 
-    #[error("ServiceError: {0}")]
-    ServiceError(#[from] ServiceError),
     #[error("RPC error: {0}")]
     RpcError(#[from] RpcError),
-    #[error("Hex conversion error: {0}")]
-    FromHexError(#[from] FromHexError),
     #[error("BitcoinError: {0}")]
     BitcoinError(#[from] BitcoinError),
     #[error("RuntimeError: {0}")]
     RuntimeError(#[from] RuntimeError),
-    #[error("SubxtError: {0}")]
-    SubxtError(#[from] SubxtError),
     #[error("CodecError: {0}")]
     CodecError(#[from] CodecError),
     #[error("BroadcastStreamRecvError: {0}")]
     BroadcastStreamRecvError(#[from] BroadcastStreamRecvError),
+}
+
+impl From<Error> for service::Error<Error> {
+    fn from(err: Error) -> Self {
+        Self::Retry(err)
+    }
 }

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -429,7 +429,7 @@ pub async fn execute_open_requests(
     num_confirmations: u32,
     payment_margin: Duration,
     auto_rbf: bool,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let parachain_rpc = &parachain_rpc;
     let vault_id = parachain_rpc.get_account_id().clone();
 

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -43,7 +43,7 @@ pub async fn process_issue_requests(
     btc_start_height: u32,
     num_confirmations: u32,
     random_delay: Arc<Box<dyn RandomDelay + Send + Sync>>,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let mut stream =
         bitcoin::stream_in_chain_transactions(bitcoin_core.clone(), btc_start_height, num_confirmations).await;
 
@@ -271,7 +271,7 @@ pub async fn listen_for_issue_requests(
     btc_parachain: InterBtcParachain,
     event_channel: Sender<Event>,
     issue_set: Arc<IssueRequests>,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let btc_parachain = &btc_parachain;
     let event_channel = &event_channel;
     let issue_set = &issue_set;
@@ -327,7 +327,7 @@ pub async fn listen_for_issue_executes(
     btc_parachain: InterBtcParachain,
     event_channel: Sender<Event>,
     issue_set: Arc<IssueRequests>,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let btc_parachain = &btc_parachain;
     let event_channel = &event_channel;
     let issue_set = &issue_set;
@@ -359,7 +359,7 @@ pub async fn listen_for_issue_executes(
 pub async fn listen_for_issue_cancels(
     btc_parachain: InterBtcParachain,
     issue_set: Arc<IssueRequests>,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let issue_set = &issue_set;
     btc_parachain
         .on_event::<CancelIssueEvent, _, _, _>(

--- a/vault/src/redeem.rs
+++ b/vault/src/redeem.rs
@@ -1,4 +1,4 @@
-use crate::{execution::*, metrics::publish_expected_bitcoin_balance, system::VaultIdManager};
+use crate::{execution::*, metrics::publish_expected_bitcoin_balance, system::VaultIdManager, Error};
 use runtime::{InterBtcParachain, RedeemPallet, RequestRedeemEvent};
 use service::{spawn_cancelable, Error as ServiceError, ShutdownSender};
 use std::time::Duration;
@@ -19,7 +19,7 @@ pub async fn listen_for_redeem_requests(
     num_confirmations: u32,
     payment_margin: Duration,
     auto_rbf: bool,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     parachain_rpc
         .on_event::<RequestRedeemEvent, _, _, _>(
             |event| async {

--- a/vault/src/refund.rs
+++ b/vault/src/refund.rs
@@ -19,7 +19,7 @@ pub async fn listen_for_refund_requests(
     num_confirmations: u32,
     process_refunds: bool,
     auto_rbf: bool,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     parachain_rpc
         .on_event::<RequestRefundEvent, _, _, _>(
             |event| async {

--- a/vault/src/relay/error.rs
+++ b/vault/src/relay/error.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::enum_variant_names)]
 
 use bitcoin::Error as BitcoinError;
-use runtime::Error as InterBtcError;
+use runtime::Error as RuntimeError;
 use thiserror::Error;
 
 #[cfg(test)]
@@ -26,8 +26,8 @@ pub enum Error {
 
     #[error("BitcoinError: {0}")]
     BitcoinError(#[from] BitcoinError),
-    #[error("InterBtcError: {0}")]
-    InterBtcError(#[from] InterBtcError),
+    #[error("RuntimeError: {0}")]
+    RuntimeError(#[from] RuntimeError),
 }
 
 #[cfg(test)]

--- a/vault/src/relay/mod.rs
+++ b/vault/src/relay/mod.rs
@@ -181,14 +181,16 @@ impl<B: Backing, I: Issuing> Runner<B, I> {
     }
 }
 
-pub async fn run_relayer(runner: Runner<DynBitcoinCoreApi, InterBtcParachain>) -> Result<(), ServiceError> {
+pub async fn run_relayer(
+    runner: Runner<DynBitcoinCoreApi, InterBtcParachain>,
+) -> Result<(), ServiceError<crate::Error>> {
     loop {
         match runner.submit_next().await {
             Ok(_) => (),
-            Err(Error::InterBtcError(ref err)) if err.is_duplicate_block() => {
+            Err(Error::RuntimeError(ref err)) if err.is_duplicate_block() => {
                 tracing::info!("Attempted to submit block that already exists")
             }
-            Err(Error::InterBtcError(ref err)) if err.is_rpc_disconnect_error() => {
+            Err(Error::RuntimeError(ref err)) if err.is_rpc_disconnect_error() => {
                 return Err(ServiceError::ClientShutdown);
             }
             Err(Error::BitcoinError(err)) if err.is_transport_error() => {

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -26,7 +26,7 @@ pub async fn listen_for_accept_replace(
     num_confirmations: u32,
     payment_margin: Duration,
     auto_rbf: bool,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let parachain_rpc = &parachain_rpc;
     let vault_id_manager = &vault_id_manager;
     let shutdown_tx = &shutdown_tx;
@@ -93,7 +93,7 @@ pub async fn listen_for_replace_requests(
     btc_rpc: VaultIdManager,
     event_channel: Sender<Event>,
     accept_replace_requests: bool,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let parachain_rpc = &parachain_rpc;
     let btc_rpc = &btc_rpc;
     let event_channel = &event_channel;
@@ -185,7 +185,7 @@ pub async fn handle_replace_request<'a, P: CollateralBalancesPallet + ReplacePal
 pub async fn listen_for_execute_replace(
     parachain_rpc: InterBtcParachain,
     event_channel: Sender<Event>,
-) -> Result<(), ServiceError> {
+) -> Result<(), ServiceError<Error>> {
     let event_channel = &event_channel;
     let parachain_rpc = &parachain_rpc;
     parachain_rpc


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

See the comment on this PR: https://github.com/interlay/interbtc-clients/pull/389

> On a side note, because we removed the checks in service to always restart on any error we will be stuck in a loop now if the wrong Bitcoin network is configured. We should distinguish between recoverable and unrecoverable errors for which this is the latter.

Specifies `Abort` and `Retry` variants on the `service::Error` enum to allow the consumer to propagate a hard-error to the `ConnectionManager`.

On a related note, I'm not sure there is any justification for the `service` logic to have its own crate since it is only ever consumed by the `vault` binary. I wonder if we should fold it in?