### PR TITLE
fix: runner: don't run invalid binaries

### DIFF
--- a/runner/src/error.rs
+++ b/runner/src/error.rs
@@ -35,6 +35,8 @@ pub enum Error {
     ClientTypeParsingError,
     #[error("Failed to derive the release name of the vault")]
     ClientNameDerivationError,
+    #[error("Incorrect Checksum")]
+    IncorrectChecksum,
 }
 
 impl<E: Into<Error> + Sized> From<BackoffError<E>> for Error {


### PR DESCRIPTION
`try_load_downloaded_binary` wasn't checking the checksum, so upon startup if the binary was incorrect, it was started anyway. See the `run_binary` right below the `try_load_downloaded_binary`