### PR TITLE
feat: extend oracle currency type to support symbol=path syntax

### DIFF
--- a/oracle-config.json
+++ b/oracle-config.json
@@ -12,6 +12,10 @@
             "name": "Kusama",
             "decimals": 12
         },
+        "LKSM": {
+            "name": "Liquid KSM",
+            "decimals": 12
+        },
         "USD": {
             "name": "United States Dollar",
             "decimals": 2
@@ -92,6 +96,20 @@
                     [
                         "USD",
                         "KSM=Kusama/0x0000000000000000000000000000000000000000"
+                    ]
+                ]
+            }
+        },
+        {
+            "pair": [
+                "BTC",
+                "LKSM"
+            ],
+            "feeds": {
+                "coingecko": [
+                    [
+                        "LKSM=liquid-ksm",
+                        "BTC"
                     ]
                 ]
             }

--- a/oracle/src/error.rs
+++ b/oracle/src/error.rs
@@ -42,7 +42,7 @@ pub enum Error {
     #[error("Invalid currency")]
     InvalidCurrency,
     #[error("Invalid config: {0}")]
-    InvalidConfig(PriceConfigError<Currency>),
+    InvalidConfig(Box<PriceConfigError<Currency>>),
     #[error("{0} not configured")]
     NotConfigured(FeedName),
     #[error("Invalid dia symbol. Base must be USD & quote must be <symbol>=<id>. E.g. STDOT=Moonbeam/0xFA36Fe1dA08C89eC72Ea1F0143a35bFd5DAea108")]

--- a/oracle/src/feeds.rs
+++ b/oracle/src/feeds.rs
@@ -51,18 +51,18 @@ trait PriceFeed {
     async fn get_price(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        currency_store: &CurrencyStore<Currency>,
+        currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error>;
 }
 
 #[derive(Default)]
 pub struct PriceFeeds {
-    currency_store: CurrencyStore<Currency>,
+    currency_store: CurrencyStore<String>,
     feeds: BTreeMap<FeedName, Box<dyn PriceFeed>>,
 }
 
 impl PriceFeeds {
-    pub fn new(currency_store: CurrencyStore<Currency>) -> Self {
+    pub fn new(currency_store: CurrencyStore<String>) -> Self {
         Self {
             currency_store,
             ..Default::default()

--- a/oracle/src/feeds/dia.rs
+++ b/oracle/src/feeds/dia.rs
@@ -40,12 +40,12 @@ impl DiaApi {
     async fn get_exchange_rate(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        _currency_store: &CurrencyStore<Currency>,
+        _currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error> {
-        if currency_pair.base != "USD" {
+        if currency_pair.base.symbol() != "USD" {
             return Err(Error::InvalidDiaSymbol);
         }
-        let token_path = currency_pair.quote.split('=').nth(1).ok_or(Error::InvalidDiaSymbol)?;
+        let token_path = currency_pair.quote.path().ok_or(Error::InvalidDiaSymbol)?;
 
         // https://docs.diadata.org/documentation/api-1/api-endpoints#asset-quotation
         let mut url = self.url.clone();
@@ -65,7 +65,7 @@ impl PriceFeed for DiaApi {
     async fn get_price(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        currency_store: &CurrencyStore<Currency>,
+        currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error> {
         self.get_exchange_rate(currency_pair, currency_store).await
     }

--- a/oracle/src/feeds/gateio.rs
+++ b/oracle/src/feeds/gateio.rs
@@ -41,15 +41,18 @@ impl GateIoApi {
     async fn get_exchange_rate(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        currency_store: &CurrencyStore<Currency>,
+        _currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error> {
         // https://www.gate.io/docs/developers/apiv4/en/
         let mut url = self.url.clone();
         url.set_path(&format!("{}/spot/tickers", url.path()));
         url.set_query(Some(&format!(
             "currency_pair={}_{}",
-            currency_store.symbol(&currency_pair.base)?,
-            currency_store.symbol(&currency_pair.quote)?,
+            currency_pair.base.path().unwrap_or_else(|| currency_pair.base.symbol()),
+            currency_pair
+                .quote
+                .path()
+                .unwrap_or_else(|| currency_pair.quote.symbol()),
         )));
 
         let data = get_http(url).await?;
@@ -67,7 +70,7 @@ impl PriceFeed for GateIoApi {
     async fn get_price(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        currency_store: &CurrencyStore<Currency>,
+        currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error> {
         self.get_exchange_rate(currency_pair, currency_store).await
     }

--- a/oracle/src/feeds/kraken.rs
+++ b/oracle/src/feeds/kraken.rs
@@ -49,13 +49,16 @@ impl KrakenApi {
     async fn get_exchange_rate(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        currency_store: &CurrencyStore<Currency>,
+        _currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error> {
         // NOTE: Kraken prefixes older cryptocurrencies with "X" and fiat with "Z"
         let asset_pair_name = format!(
             "{}{}",
-            currency_store.symbol(&currency_pair.base)?,
-            currency_store.symbol(&currency_pair.quote)?,
+            currency_pair.base.path().unwrap_or_else(|| currency_pair.base.symbol()),
+            currency_pair
+                .quote
+                .path()
+                .unwrap_or_else(|| currency_pair.quote.symbol()),
         );
 
         // https://docs.kraken.com/rest/
@@ -79,7 +82,7 @@ impl PriceFeed for KrakenApi {
     async fn get_price(
         &self,
         currency_pair: CurrencyPair<Currency>,
-        currency_store: &CurrencyStore<Currency>,
+        currency_store: &CurrencyStore<String>,
     ) -> Result<CurrencyPairAndPrice<Currency>, Error> {
         self.get_exchange_rate(currency_pair, currency_store).await
     }


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Deserializes into `Currency::Symbol` and `Currency::SymbolAndPath` to support overriding the exchange path.

Closes #399 




