### PR TITLE
Prometheus rules for redeem not serviced, and crash loop

### DIFF
--- a/.deploy/monitoring/prometheus.yml
+++ b/.deploy/monitoring/prometheus.yml
@@ -20,7 +20,7 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name: 'service-collector'
+  - job_name: 'interlay-vault'
     static_configs:
       - targets: ['localhost:9615']
 

--- a/.deploy/monitoring/prometheus.yml
+++ b/.deploy/monitoring/prometheus.yml
@@ -20,7 +20,7 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name: 'interlay-vault'
+  - job_name: 'vault'
     static_configs:
       - targets: ['localhost:9615']
 

--- a/.deploy/monitoring/rules.yml
+++ b/.deploy/monitoring/rules.yml
@@ -6,22 +6,21 @@ groups:
     expr: collateralization < 2.6 and collateralization > 0.01
     for: 1m
     annotations:
-      description: 'Vault {{ $labels.job }} with currency pair {{ $labels.currency }} and {{ $value }} collateralization is below the Secure Threshold.'
+      description: 'Vault with currency pair {{ $labels.currency }} and {{ $value }} collateralization is below the Secure Threshold.'
     labels:
       severity: 'critical'
   - alert: RedeemPending
     expr: remaining_time_to_redeem_hours <= 46 and remaining_time_to_redeem_hours > 0.01
     for: 1m
     annotations:
-      description: 'Redeem almost expired for vault {{ $labels.job }} with currency pair {{ $labels.currency }}. Remaining time: {{ $value }}.'
+      description: 'Redeem almost expired for Vault with currency pair {{ $labels.currency }}. Remaining time: {{ $value }} hour(s).'
     labels:
       severity: 'critical'
   - alert: VaultsTooManyRestarts
-    expr: changes(process_start_time_seconds{job=~"kintsugi-vault|interlay-vault"}[15m]) > 2
+    expr: changes(process_start_time_seconds{job=~"vault"}[15m]) > 2
     for: 5m
     labels:
       severity: warning
     annotations:
-      summary: "Vault {{ $labels.job }} has restarted too frequently."
-      description: "Vault {{ $labels.job }} has restarted more than twice in the last 15 minutes. It might be crashlooping."
-
+      summary: "Vault {{ $labels.currency }} has restarted too frequently."
+      description: "Vault {{ $labels.currency }} has restarted more than twice in the last 15 minutes. It might be crashlooping."

--- a/.deploy/monitoring/rules.yml
+++ b/.deploy/monitoring/rules.yml
@@ -1,20 +1,27 @@
-# Default alerting rules.
-# - Vault collateralization is below the secure threshold.
-# - A redeem has less than an hour until it expires.
+# Default Kintsugi/Interlay vault alerting rules.
 groups:
 - name: VaultMonitoring
   rules:
   - alert: BelowSecureThreshold
-    expr: collateralization < 2.6
-    for: 1s
+    expr: collateralization < 2.6 and collateralization > 0.01
+    for: 1m
     annotations:
-      description: 'Vault with currency pair {{ $labels.currency }} is below the Secure Threshold.'
+      description: 'Vault {{ $labels.job }} with currency pair {{ $labels.currency }} and {{ $value }} collateralization is below the Secure Threshold.'
     labels:
       severity: 'critical'
-  - alert: RedeemAlmostExpired
-    expr: remaining_time_to_redeem_hours == 1
-    for: 1s
+  - alert: RedeemPending
+    expr: remaining_time_to_redeem_hours <= 46 and remaining_time_to_redeem_hours > 0.01
+    for: 1m
     annotations:
-      description: 'Redeem almost expired for Vault with currency pair {{ $labels.currency }}.'
+      description: 'Redeem almost expired for vault {{ $labels.job }} with currency pair {{ $labels.currency }}. Remaining time: {{ $value }}.'
     labels:
       severity: 'critical'
+  - alert: VaultsTooManyRestarts
+    expr: changes(process_start_time_seconds{job=~"kintsugi-vault|interlay-vault"}[15m]) > 2
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Vault {{ $labels.job }} has restarted too frequently."
+      description: "Vault {{ $labels.job }} has restarted more than twice in the last 15 minutes. It might be crashlooping."
+

--- a/.deploy/monitoring/test.yml
+++ b/.deploy/monitoring/test.yml
@@ -17,7 +17,7 @@ tests:
                       severity: critical
                       currency: KSM_KBTC
                   exp_annotations:
-                      description: "Vault with currency pair KSM_KBTC is below the Secure Threshold."
+                      description: "Vault with currency pair KSM_KBTC and 2.5 collateralization is below the Secure Threshold."
     # Test 2.
     - interval: 1m
       input_series:
@@ -27,6 +27,7 @@ tests:
           - eval_time: 1m
             exp_alerts:
             # No alerts.
+              []
     # Test 3.
     - interval: 1m
       input_series:
@@ -34,13 +35,13 @@ tests:
             values: '1'
       alert_rule_test:
           - eval_time: 1m
-            alertname: RedeemAlmostExpired
+            alertname: RedeemPending
             exp_alerts:
                 - exp_labels:
                       severity: critical
                       currency: KSM_KBTC
                   exp_annotations:
-                      description: "Redeem almost expired for Vault with currency pair KSM_KBTC."
+                      description: "Redeem almost expired for Vault with currency pair KSM_KBTC. Remaining time: 1 hour(s)."
     # Test 4.
     - interval: 1m
       input_series:
@@ -50,6 +51,7 @@ tests:
           - eval_time: 1m
             exp_alerts:
             # No alerts.
+              []
     # Test 5.
     - interval: 1m
       input_series:
@@ -57,7 +59,27 @@ tests:
             values: '2'
       alert_rule_test:
           - eval_time: 1m
+            alertname: RedeemPending
             exp_alerts:
-            # No alerts.
-
+                - exp_labels:
+                      severity: critical
+                      currency: KSM_KBTC
+                  exp_annotations:
+                      description: "Redeem almost expired for Vault with currency pair KSM_KBTC. Remaining time: 2 hour(s)."
+    # Test 6.
+    - interval: 1m
+      input_series:
+          - series: 'process_start_time_seconds{job="vault", currency="KSM_KBTC"}'
+            values: '1668014743.01 1668014750.22 1668014766.80 1668014773.1'
+      alert_rule_test:
+          - eval_time: 15m
+            alertname: VaultsTooManyRestarts
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                      currency: KSM_KBTC
+                      job: vault
+                  exp_annotations:
+                      description: "Vault KSM_KBTC has restarted more than twice in the last 15 minutes. It might be crashlooping."
+                      summary: "Vault KSM_KBTC has restarted too frequently."
 


### PR DESCRIPTION
Add/improve Prometheus rules for:
* vault startup doom loop (if bitcoind can't service RPC requests in time)
* new redeem not serviced yet
* below secure threshold

In particular, set a minimum (0.01) for some values to avoid false negative alerts.