### PR TITLE
Fix: bail on stream failure

### DIFF
--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -4,7 +4,7 @@ mod http;
 use clap::Parser;
 use error::Error;
 use git_version::git_version;
-use runtime::InterBtcSigner;
+use runtime::{InterBtcSigner, ShutdownSender};
 use service::{on_shutdown, wait_or_shutdown};
 use std::net::SocketAddr;
 
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Error> {
     let (key_pair, _) = opts.account_info.get_key_pair()?;
     let signer = InterBtcSigner::new(key_pair);
 
-    let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+    let shutdown_tx = ShutdownSender::new();
 
     let parachain_config = opts.parachain;
     let faucet_config = opts.faucet;

--- a/oracle/src/main.rs
+++ b/oracle/src/main.rs
@@ -12,7 +12,7 @@ use futures::future::join_all;
 use git_version::git_version;
 use runtime::{
     cli::{parse_duration_ms, ProviderUserOpts},
-    CurrencyId, FixedU128, InterBtcParachain, InterBtcSigner, OracleKey, OraclePallet, TryFromSymbol,
+    CurrencyId, FixedU128, InterBtcParachain, InterBtcSigner, OracleKey, OraclePallet, ShutdownSender, TryFromSymbol,
 };
 use std::{path::PathBuf, time::Duration};
 use tokio::{join, time::sleep};
@@ -188,7 +188,7 @@ async fn _main() -> Result<(), Error> {
         .collect::<Result<Vec<_>, _>>()?;
 
         // get prices above first to prevent websocket timeout
-        let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+        let shutdown_tx = ShutdownSender::new();
         let parachain_rpc = InterBtcParachain::from_url_with_retry(
             &opts.btc_parachain_url,
             signer.clone(),

--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -101,7 +101,7 @@ pub async fn default_provider_client(key: AccountKeyring) -> (SubxtClient, TempD
 /// Create a new parachain_rpc with the given keyring
 pub async fn setup_provider(client: SubxtClient, key: AccountKeyring) -> InterBtcParachain {
     let signer = InterBtcSigner::new(key.pair());
-    let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+    let shutdown_tx = crate::ShutdownSender::new();
 
     InterBtcParachain::new(client, signer, shutdown_tx)
         .await

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,6 +8,7 @@ mod conn;
 mod error;
 mod retry;
 mod rpc;
+mod shutdown;
 
 pub mod types;
 
@@ -39,6 +40,7 @@ pub use rpc::{
     OraclePallet, RedeemPallet, ReplacePallet, SecurityPallet, TimestampPallet, UtilFuncs, VaultRegistryPallet,
     DEFAULT_SPEC_NAME, SS58_PREFIX,
 };
+pub use shutdown::{ShutdownReceiver, ShutdownSender};
 pub use sp_arithmetic::{traits as FixedPointTraits, FixedI128, FixedPointNumber, FixedU128};
 pub use std::collections::btree_set::BTreeSet;
 use std::time::Duration;

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -216,8 +216,7 @@ impl InterBtcParachain {
             .fetch(&storage_key, None)
             .await
             .transpose()
-            .map(|x| x.ok())
-            .flatten()
+            .and_then(|x| x.ok())
             .map(|x| x.nonce)
             .unwrap_or_default();
 
@@ -444,7 +443,7 @@ impl InterBtcParachain {
                                 break;
                             }
                         }
-                        Err(err) => on_error(err.into()),
+                        Err(err) => on_error(err),
                     }
                 }
                 Result::<(), _>::Err(Error::ChannelClosed)

--- a/runtime/src/rpc.rs
+++ b/runtime/src/rpc.rs
@@ -4,6 +4,8 @@ use crate::{
     types::*,
     AccountId, AssetRegistry, CurrencyId, Error, InterBtcRuntime, InterBtcSigner, RetryPolicy, RichH256Le, SubxtError,
 };
+
+pub use crate::ShutdownSender;
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use futures::{future::join_all, stream::StreamExt, FutureExt, SinkExt};
@@ -23,7 +25,6 @@ use tokio::{
     sync::RwLock,
     time::{sleep, timeout},
 };
-
 // timeout before retrying parachain calls (5 minutes)
 const TRANSACTION_TIMEOUT: Duration = Duration::from_secs(300);
 
@@ -60,7 +61,6 @@ cfg_if::cfg_if! {
     }
 }
 
-pub(crate) type ShutdownSender = tokio::sync::broadcast::Sender<()>;
 pub(crate) type FeeRateUpdateSender = tokio::sync::broadcast::Sender<FixedU128>;
 pub type FeeRateUpdateReceiver = tokio::sync::broadcast::Receiver<FixedU128>;
 

--- a/runtime/src/shutdown.rs
+++ b/runtime/src/shutdown.rs
@@ -47,6 +47,12 @@ impl ShutdownSender {
     }
 }
 
+impl Default for ShutdownSender {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct ShutdownReceiver {
     received_shutdown: bool,
     inner: tokio::sync::broadcast::Receiver<()>,
@@ -55,7 +61,7 @@ pub struct ShutdownReceiver {
 impl ShutdownReceiver {
     pub async fn recv(&mut self) -> Result<(), RecvError> {
         if self.received_shutdown {
-            return Ok(());
+            Ok(())
         } else {
             self.inner.recv().await
         }

--- a/runtime/src/shutdown.rs
+++ b/runtime/src/shutdown.rs
@@ -1,0 +1,63 @@
+use std::sync::{Arc, RwLock};
+use tokio::sync::broadcast::error::{RecvError, SendError};
+
+/// A wrapper arround a tokio broadcast channel that makes sure that
+/// listeners created after a shutdown signal has already been sent
+/// also receive the shutdown signal.
+#[derive(Clone)]
+pub struct ShutdownSender {
+    pub sent_shutdown: Arc<RwLock<bool>>,
+    pub channel: tokio::sync::broadcast::Sender<()>,
+}
+
+impl ShutdownSender {
+    pub fn new() -> Self {
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+        Self {
+            sent_shutdown: Arc::new(RwLock::new(false)),
+            channel: shutdown_tx,
+        }
+    }
+
+    pub fn send(&self, value: ()) -> Result<usize, SendError<()>> {
+        // Record that we sent the signal for listeners created in the future.
+        // Note that unwrap is suitable here since the read only fails if a thread
+        // holding the lock has panicked, in which case propagating the panic is
+        // generally advised to prevent operating on unexpected state.
+        *self.sent_shutdown.write().unwrap() = true;
+
+        self.channel.send(value)
+    }
+
+    pub fn subscribe(&self) -> ShutdownReceiver {
+        let subscription = self.channel.subscribe();
+        // Check if signal was already sent before we started listening.
+        // Note that unwrap is suitable here since the read only fails if a thread
+        // holding the lock has panicked, in which case propagating the panic is
+        // generally advised to prevent operating on unexpected state.
+        let sent = *self.sent_shutdown.read().unwrap();
+        ShutdownReceiver {
+            received_shutdown: sent,
+            inner: subscription,
+        }
+    }
+
+    pub fn receiver_count(&self) -> usize {
+        self.channel.receiver_count()
+    }
+}
+
+pub struct ShutdownReceiver {
+    received_shutdown: bool,
+    inner: tokio::sync::broadcast::Receiver<()>,
+}
+
+impl ShutdownReceiver {
+    pub async fn recv(&mut self) -> Result<(), RecvError> {
+        if self.received_shutdown {
+            return Ok(());
+        } else {
+            self.inner.recv().await
+        }
+    }
+}

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -15,11 +15,9 @@ mod trace;
 
 pub use cli::{LoggingFormat, MonitoringConfig, RestartPolicy, ServiceConfig};
 pub use error::Error;
+pub use runtime::{ShutdownReceiver, ShutdownSender};
 pub use trace::init_subscriber;
 pub use warp;
-
-pub type ShutdownSender = tokio::sync::broadcast::Sender<()>;
-pub type ShutdownReceiver = tokio::sync::broadcast::Receiver<()>;
 
 pub type DynBitcoinCoreApi = Arc<dyn BitcoinCoreApi + Send + Sync>;
 
@@ -82,7 +80,7 @@ impl<Config: Clone + Send + 'static, F: Fn()> ConnectionManager<Config, F> {
             tracing::info!("AccountId: {}", self.signer.account_id().pretty_print());
 
             let config = self.config.clone();
-            let (shutdown_tx, _) = tokio::sync::broadcast::channel(16);
+            let shutdown_tx = ShutdownSender::new();
 
             let prefix = self.wallet_name.clone().unwrap_or_else(|| "vault".to_string());
             let bitcoin_core = self.bitcoin_config.new_client(Some(format!("{prefix}-master"))).await?;

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -476,13 +476,9 @@ pub async fn execute_open_requests(
             tokio::task::yield_now().await;
         }
 
-        let tx = match result {
-            Ok(x) => x,
-            Err(e) => {
-                tracing::warn!("Failed to process transaction: {}", e);
-                continue;
-            }
-        };
+        // Bail on any errors because if we miss any transactions we could end up
+        // double paying
+        let tx = result?;
 
         // get the request this transaction corresponds to, if any
         if let Some(request) = get_request_for_btc_tx(&tx, &open_requests) {

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -476,9 +476,23 @@ pub async fn execute_open_requests(
             tokio::task::yield_now().await;
         }
 
-        // Bail on any errors because if we miss any transactions we could end up
-        // double paying
-        let tx = result?;
+        // When there is an error, we have to make a choice. Either we restart or
+        // continue processing. Both options have their risks: if we restart, it's
+        // possible that the vault will never manage to start up, causing us to
+        // fail to process requests. On the other hand, if we ignore transactions,
+        // we risk double paying. We choose to restart only for network errors,
+        // since these are not expected to be persistent. Other errors could be
+        // persistent, so we keep going.
+        let tx = match result {
+            Ok(x) => x,
+            Err(e) if e.is_transport_error() => {
+                return Err(e.into());
+            }
+            Err(e) => {
+                tracing::warn!("Failed to process transaction: {}", e);
+                continue;
+            }
+        };
 
         // get the request this transaction corresponds to, if any
         if let Some(request) = get_request_for_btc_tx(&tx, &open_requests) {


### PR DESCRIPTION
When an error is received in transcation stream in `execution::execute_open_requests`, we have to make a choice. Either we restart or continue processing. Both options have their risks: if we restart, it's possible that the vault will never manage to start up, causing us tofail to process requests. On the other hand, if we ignore transactions,we risk double paying. We choose to restart only for network errors, since these are not expected to be persistent. Other errors could be persistent, so we keep going.

I created a `ShutdownSender` struct that checks if a shutdown signal was sent before a receiver started listening. Without this, such events would be missed and the service would not shut down. 