### PR TITLE
fix: install protobuf before docs build

### DIFF
--- a/.github/workflows/cargo-docs.yml
+++ b/.github/workflows/cargo-docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install System Dependencies
         run: |
             sudo apt-get update && sudo apt-get install -y \
-            cmake pkg-config libssl-dev git clang curl libc6-dev
+            cmake pkg-config libssl-dev git clang curl libc6-dev protobuf-compiler
       - name: Set variables
         run: |
             echo "TOOLCHAIN=$(rustup show active-toolchain | cut -d " " -f1)" >> $GITHUB_ENV


### PR DESCRIPTION
The docs build is [failing](https://github.com/interlay/interbtc-clients/actions/runs/3532233812/jobs/5926340162) with the same `protoc` error as in [this run](https://github.com/interlay/interbtc-clients/actions/runs/3524840585/jobs/5910782021), this patch should fix that