### PR TITLE
Always send shutdown signal on error

### DIFF
--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -1,6 +1,6 @@
 pub use jsonrpsee::core::Error as JsonRpseeError;
 
-use crate::{types::*, BTC_RELAY_MODULE, ISSUE_MODULE, SYSTEM_MODULE};
+use crate::{types::*, BTC_RELAY_MODULE, ISSUE_MODULE, SYSTEM_MODULE, VAULT_REGISTRY_MODULE};
 use codec::Error as CodecError;
 use jsonrpsee::{
     client_transport::ws::WsHandshakeError,
@@ -115,6 +115,13 @@ impl Error {
 
     pub fn is_issue_completed(&self) -> bool {
         self.is_module_err(ISSUE_MODULE, &format!("{:?}", IssuePalletError::IssueCompleted))
+    }
+
+    pub fn is_threshold_not_set(&self) -> bool {
+        self.is_module_err(
+            VAULT_REGISTRY_MODULE,
+            &format!("{:?}", VaultRegistryPalletError::ThresholdNotSet),
+        )
     }
 
     fn map_custom_error<T>(&self, call: impl Fn(&ErrorObjectOwned) -> Option<T>) -> Option<T> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -55,6 +55,7 @@ pub const BTC_RELAY_MODULE: &str = "BTCRelay";
 pub const ISSUE_MODULE: &str = "Issue";
 pub const SECURITY_MODULE: &str = "Security";
 pub const SYSTEM_MODULE: &str = "System";
+pub const VAULT_REGISTRY_MODULE: &str = "VaultRegistry";
 
 pub const STABLE_BITCOIN_CONFIRMATIONS: &str = "StableBitcoinConfirmations";
 pub const STABLE_PARACHAIN_CONFIRMATIONS: &str = "StableParachainConfirmations";

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -81,7 +81,7 @@ mod metadata_aliases {
     pub use metadata::runtime_types::{
         btc_relay::pallet::Error as BtcRelayPalletError, frame_system::pallet::Error as SystemPalletError,
         issue::pallet::Error as IssuePalletError, redeem::pallet::Error as RedeemPalletError,
-        security::pallet::Error as SecurityPalletError,
+        security::pallet::Error as SecurityPalletError, vault_registry::pallet::Error as VaultRegistryPalletError,
     };
 
     pub use metadata::runtime_types::bitcoin::types::H256Le;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -135,6 +135,8 @@ impl<Config: Clone + Send + 'static, F: Fn()> ConnectionManager<Config, F> {
                     tracing::warn!("Disconnected");
                 }
             }
+            // propagate shutdown signal from main tasks
+            let _ = shutdown_tx.send(());
 
             let rate_limiter = RateLimiter::direct(Quota::per_minute(nonzero!(4u32)));
 

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -527,10 +527,11 @@ impl VaultService {
         };
         tracing::info!("Using {} bitcoin confirmations", num_confirmations);
 
-        // Subscribe to an event (any event will do) so that a period of inactivity does not close the jsonrpsee
-        // connection
+        // Subscribe to an event (any event will do) so that a period of inactivity
+        // does not close the jsonrpsee connection
         tracing::info!("Subscribing to error events...");
         let err_provider = self.btc_parachain.clone();
+        // NOTE: this will block if subsequent errors do not trigger shutdown
         let err_listener = wait_or_shutdown(self.shutdown.clone(), async move {
             err_provider
                 .on_event_error(|e| tracing::debug!("Received error event: {}", e))


### PR DESCRIPTION
and abort the process if the required threshold is not set. We saw an error on testnet where the Vault would fail to shutdown if started with an invalid currency - i.e. there was no threshold set for that collateral type. The error listener would block shutdown since nothing actually sent the shutdown signal. This was because the error was from the startup sequence, not the spawned sub-tasks where we usually incur errors.