### PR TITLE
fix: vault registration when using faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14447,6 +14447,7 @@ dependencies = [
  "async-trait",
  "bitcoin 1.1.0",
  "clap",
+ "faucet",
  "frame-support",
  "futures 0.3.25",
  "git-version",

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Interlay <contact@interlay.io>"]
 edition = "2018"
 description = "Collateral faucet for the BTC Parachain."
 
+[lib]
+name = "shared"
+path = "src/lib.rs"
+
 [features]
 parachain-metadata-interlay = ["runtime/parachain-metadata-interlay"]
 parachain-metadata-kintsugi = ["runtime/parachain-metadata-kintsugi"]

--- a/faucet/src/lib.rs
+++ b/faucet/src/lib.rs
@@ -1,0 +1,14 @@
+use parity_scale_codec::{Decode, Encode};
+use serde::Deserialize;
+#[derive(Deserialize, Debug, Clone, Encode, Decode)]
+pub struct AllowanceAmount {
+    pub symbol: String,
+    pub amount: u128,
+}
+impl AllowanceAmount {
+    pub fn new(symbol: String, amount: u128) -> Self {
+        Self { symbol, amount }
+    }
+}
+
+pub type Allowance = Vec<AllowanceAmount>;

--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -4,12 +4,11 @@ mod http;
 use clap::Parser;
 use error::Error;
 use git_version::git_version;
-use parity_scale_codec::Encode;
 use runtime::{InterBtcSigner, ShutdownSender};
 use serde::Deserialize;
 use service::{on_shutdown, wait_or_shutdown};
+use shared::{Allowance, AllowanceAmount};
 use std::{net::SocketAddr, path::PathBuf};
-
 const VERSION: &str = git_version!(args = ["--tags"]);
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 const NAME: &str = env!("CARGO_PKG_NAME");
@@ -34,19 +33,6 @@ struct Opts {
     #[clap(long, default_value = "./faucet-allowance-config.json")]
     allowance_config: PathBuf,
 }
-
-#[derive(Deserialize, Debug, Clone, Encode)]
-pub struct AllowanceAmount {
-    symbol: String,
-    amount: u128,
-}
-impl AllowanceAmount {
-    pub fn new(symbol: String, amount: u128) -> Self {
-        Self { symbol, amount }
-    }
-}
-
-type Allowance = Vec<AllowanceAmount>;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct AllowanceConfig {

--- a/vault/Cargo.toml
+++ b/vault/Cargo.toml
@@ -46,6 +46,7 @@ jsonrpc-core-client = { version = "18.0.0", features = ["http", "tls"] }
 bitcoin = { path = "../bitcoin", features = ["cli"] }
 runtime = { path = "../runtime" }
 service = { path = "../service" }
+faucet-rpc = { package = "faucet", path = "../faucet" }
 
 # Substrate dependencies
 # needs to agree with subxt's version

--- a/vault/src/error.rs
+++ b/vault/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     DeadlineExpired,
     #[error("Faucet url not set")]
     FaucetUrlNotSet,
+    #[error("Faucet allowance for `{0}` not set")]
+    FaucetAllowanceNotSet(String),
 
     #[error("RPC error: {0}")]
     RpcError(#[from] RpcError),


### PR DESCRIPTION
The faucet http api was changed in https://github.com/interlay/interbtc-clients/pull/422 but the vault side was not updated, resulting in vaults attempting to register with ridiculous amounts.