### PR TITLE
fix(oracle): return asset-per-usd instead of usd-per-asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15238,11 +15238,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "sp-serializer"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.36#cb4f2491b00af7d7817f3a54209c26b20faa1f51"
-
-[[patch.unused]]
 name = "orml-xcm"
 version = "0.4.1-dev"
 source = "git+https://github.com/open-web3-stack//open-runtime-module-library?rev=24f0a8b6e04e1078f70d0437fb816337cdf4f64c#24f0a8b6e04e1078f70d0437fb816337cdf4f64c"
+
+[[patch.unused]]
+name = "sp-serializer"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.36#cb4f2491b00af7d7817f3a54209c26b20faa1f51"


### PR DESCRIPTION
Prices that were fetched from DIA were incorrect, we need to use the reciprocal. Also making the trailing slash of the dia url optional. Currently the path is required to not have a trailing slash, which is inconsistent with the other feeds.