### PR TITLE
fix: catch and retry on 'wallet already loading' error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15239,11 +15239,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "orml-xcm"
-version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack//open-runtime-module-library?rev=24f0a8b6e04e1078f70d0437fb816337cdf4f64c#24f0a8b6e04e1078f70d0437fb816337cdf4f64c"
-
-[[patch.unused]]
 name = "sp-serializer"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.36#cb4f2491b00af7d7817f3a54209c26b20faa1f51"
+
+[[patch.unused]]
+name = "orml-xcm"
+version = "0.4.1-dev"
+source = "git+https://github.com/open-web3-stack//open-runtime-module-library?rev=24f0a8b6e04e1078f70d0437fb816337cdf4f64c#24f0a8b6e04e1078f70d0437fb816337cdf4f64c"

--- a/bitcoin/src/error.rs
+++ b/bitcoin/src/error.rs
@@ -95,6 +95,18 @@ impl Error {
         )
     }
 
+    pub fn is_already_loading_wallet_error(&self) -> bool {
+        // Catch this error: `JSON-RPC error: RPC error response: RpcError { code: -4, message: "Wallet already
+        // loading.", data: None }`.
+        // In older versions, the message was "Wallet already being loading.". See https://github.com/bitcoin/bitcoin/commit/ae9d26a8f0435e2f4b39ad1181473e6575ac67b5
+        // We catch everything that starts with "Wallet already". As of the time of writing no error error messages
+        // start with that
+        matches!(self,
+            Error::BitcoinError(BitcoinError::JsonRpc(JsonRpcError::Rpc(err)))
+                if BitcoinRpcError::from(err.clone()) == BitcoinRpcError::RpcWalletError && err.message.starts_with("Wallet already")
+        )
+    }
+
     pub fn rejected_by_network_rules(&self) -> bool {
         matches!(self,
             Error::BitcoinError(BitcoinError::JsonRpc(JsonRpcError::Rpc(err)))


### PR DESCRIPTION
Closes https://github.com/interlay/interbtc-clients/issues/429.

I'm unable to verify until the next time my wallet hasn't been updated in a while