### PR TITLE
chore: lockfile check script

### DIFF
--- a/scripts/lockfile-check/Cargo.toml
+++ b/scripts/lockfile-check/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lockfile-check"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cargo-lock = "8.0.2"

--- a/scripts/lockfile-check/src/main.rs
+++ b/scripts/lockfile-check/src/main.rs
@@ -1,0 +1,34 @@
+use cargo_lock::Lockfile;
+
+fn get_unpatched_crate(org: &str, repo: &str) -> Vec<String> {
+    let lockfile = Lockfile::load("<edit-this-to-some-path>/Cargo.lock").unwrap();
+    let repo_path = org.to_owned() + repo;
+    lockfile.packages.into_iter().filter_map(|package| {
+        let source = package.source?;
+        if source.is_git() {
+            if source.url().path().contains(&repo_path) {
+                return Some(package.name.as_str().to_string())
+            }
+        }
+        None
+    }).collect()
+}
+
+fn print_unpatched_repos(org: &str, repo: &str) {
+    let repos = get_unpatched_crate(org, repo);
+    if repos.len() > 0 {
+        println!("Unpatched {repo} dependencies:");
+        for repo in repos {
+            println!("{repo}");
+        }
+        println!("");
+        println!("");
+    }
+}
+
+fn main() {
+    for repo in ["substrate", "polkadot", "cumulus"] {
+        print_unpatched_repos("paritytech/", repo);
+    }
+    print_unpatched_repos("open-web3-stack/", "open-runtime-module-library");
+}


### PR DESCRIPTION
A script that I wrote a while ago that checks for unpatched repos in the lockfile. Whenever we upgrade polkadot versions it's common that some crates need to be added to the patch list. This script prints such unpatches crates. 