### PR TITLE
feat: add signal-hook to oracle client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6822,6 +6822,8 @@ dependencies = [
  "runtime",
  "serde",
  "serde_json",
+ "signal-hook",
+ "signal-hook-tokio",
  "statrs",
  "thiserror",
  "tokio",
@@ -15978,11 +15980,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "sp-serializer"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
-
-[[patch.unused]]
 name = "orml-xcm"
 version = "0.4.1-dev"
 source = "git+https://github.com/open-web3-stack//open-runtime-module-library?rev=24f0a8b6e04e1078f70d0437fb816337cdf4f64c#24f0a8b6e04e1078f70d0437fb816337cdf4f64c"
+
+[[patch.unused]]
+name = "sp-serializer"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -16,6 +16,8 @@ log = "0.4.0"
 env_logger = "0.7.1"
 clap = { version = "4.0.17", features = ["derive"]}
 tokio = { version = "1.0", features = ["full"] }
+signal-hook = "0.3.14"
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 chrono = "0.4.22"
 thiserror = "1.0"
 reqwest = { version = "0.11.4", features = ["json"] }


### PR DESCRIPTION
Closes #454

Explicitly catch termination signals as suggested [here](https://stackoverflow.com/a/60812082) - there is an issue with using the oracle client in docker where it fails to shutdown immediately.