### PR TITLE
fix: runner: reconnect after parachain connection error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15985,11 +15985,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "sp-serializer"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
-
-[[patch.unused]]
 name = "orml-xcm"
 version = "0.4.1-dev"
 source = "git+https://github.com/open-web3-stack//open-runtime-module-library?rev=24f0a8b6e04e1078f70d0437fb816337cdf4f64c#24f0a8b6e04e1078f70d0437fb816337cdf4f64c"
+
+[[patch.unused]]
+name = "sp-serializer"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"


### PR DESCRIPTION
Don't bail on parachain connection error. Instead, try to reconnect next block. Note that the startup behavior is unchanged, in that failure to connect upon startup is still considered a fatal error (which is useful in case the user supplies in invalid url: they get fast feedback that it's not going to work). 