### PR TITLE
fix(metrics): ForeignAsset and LendToken collateral formatting and parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15985,11 +15985,11 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "sp-serializer"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
-
-[[patch.unused]]
 name = "orml-xcm"
 version = "0.4.1-dev"
 source = "git+https://github.com/open-web3-stack//open-runtime-module-library?rev=24f0a8b6e04e1078f70d0437fb816337cdf4f64c#24f0a8b6e04e1078f70d0437fb816337cdf4f64c"
+
+[[patch.unused]]
+name = "sp-serializer"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"

--- a/faucet/src/http.rs
+++ b/faucet/src/http.rs
@@ -158,8 +158,7 @@ async fn ensure_funding_allowed(
             .get_reserved_balance_for_id(account_id.clone(), *currency_id)
             .await?;
 
-        let one = |currency: CurrencyId| Ok::<_, Error>(10u128.pow(currency.decimals()?));
-        if free_balance + reserved_balance > allowance_config.max_fundable_client_balance * one(*currency_id)? {
+        if free_balance + reserved_balance > allowance_config.max_fundable_client_balance * currency_id.one()? {
             log::warn!(
                 "User {} has enough {:?} funds: {:?}",
                 account_id,
@@ -614,7 +613,7 @@ mod tests {
             if bob_provider.get_public_key().await.unwrap().is_none() {
                 bob_provider.register_public_key(dummy_public_key()).await.unwrap();
             }
-            let one_unit = 10u128.pow(currency_id.decimals().unwrap());
+            let one_unit = currency_id.one().unwrap();
             bob_provider.register_vault(&bob_vault_id, 55 * one_unit).await.unwrap();
 
             let alice_provider = setup_provider(client.clone(), AccountKeyring::Alice).await;

--- a/runtime/src/assets.rs
+++ b/runtime/src/assets.rs
@@ -170,6 +170,7 @@ impl TryFromSymbol for CurrencyId {
 pub trait RuntimeCurrencyInfo {
     fn symbol(&self) -> Result<String, Error>;
     fn decimals(&self) -> Result<u32, Error>;
+    fn one(&self) -> Result<u128, Error>;
     fn coingecko_id(&self) -> Result<String, Error>;
 }
 
@@ -201,6 +202,11 @@ impl RuntimeCurrencyInfo for CurrencyId {
             }
             _ => Err(Error::TokenUnsupported),
         }
+    }
+
+    fn one(&self) -> Result<u128, Error> {
+        let decimals = self.decimals()?;
+        Ok(10u128.pow(decimals))
     }
 
     fn coingecko_id(&self) -> Result<String, Error> {
@@ -253,6 +259,8 @@ mod tests {
     fn should_get_runtime_info_for_token_symbol() -> Result<(), Error> {
         assert_eq!(Token(DOT).symbol()?, "DOT");
         assert_eq!(Token(DOT).decimals()?, 10);
+        assert_eq!(Token(DOT).one()?, 10000000000);
+        assert_eq!(Token(IBTC).one()?, 100000000);
         Ok(())
     }
 
@@ -295,6 +303,7 @@ mod tests {
 
         assert_eq!(ForeignAsset(0).symbol()?, "AST1");
         assert_eq!(ForeignAsset(0).decimals()?, 10);
+        assert_eq!(ForeignAsset(0).one()?, 10000000000);
         Ok(())
     }
 }

--- a/runtime/src/assets.rs
+++ b/runtime/src/assets.rs
@@ -37,7 +37,7 @@ impl AssetRegistry {
         Ok(())
     }
 
-    pub(crate) fn insert(foreign_asset_id: u32, asset_metadata: AssetMetadata) -> Result<(), Error> {
+    pub fn insert(foreign_asset_id: u32, asset_metadata: AssetMetadata) -> Result<(), Error> {
         let mut asset_registry = Self::global()?;
         asset_registry.inner_insert(foreign_asset_id, asset_metadata)?;
         Ok(())
@@ -88,7 +88,7 @@ impl LendingAssets {
         LENDING_ASSETS.lock().map_err(|_| Error::CannotOpenAssetRegistry)
     }
 
-    pub(crate) fn insert(underlying_id: CurrencyId, lend_token_id: CurrencyId) -> Result<(), Error> {
+    pub fn insert(underlying_id: CurrencyId, lend_token_id: CurrencyId) -> Result<(), Error> {
         log::info!(
             "Found loans market: {:?}, with lend token: {:?}",
             underlying_id,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,7 +29,7 @@ use subxt::{
 };
 
 pub use addr::PartialAddress;
-pub use assets::{AssetRegistry, RuntimeCurrencyInfo, TryFromSymbol};
+pub use assets::{AssetRegistry, LendingAssets, RuntimeCurrencyInfo, TryFromSymbol};
 pub use error::{Error, SubxtError};
 pub use primitives::CurrencyInfo;
 pub use prometheus;

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -14,8 +14,8 @@ use runtime::{
         gather, proto::MetricFamily, Encoder, Gauge, GaugeVec, IntCounter, IntGauge, IntGaugeVec, Opts, Registry,
         TextEncoder,
     },
-    CollateralBalancesPallet, CurrencyId, CurrencyIdExt, CurrencyInfo, Error as RuntimeError, FeedValuesEvent,
-    FixedU128, InterBtcParachain, InterBtcRedeemRequest, IssuePallet, IssueRequestStatus, OracleKey, RedeemPallet,
+    CollateralBalancesPallet, CurrencyId, CurrencyIdExt, Error as RuntimeError, FeedValuesEvent, FixedU128,
+    InterBtcParachain, InterBtcRedeemRequest, IssuePallet, IssueRequestStatus, OracleKey, RedeemPallet,
     RedeemRequestStatus, ReplacePallet, RuntimeCurrencyInfo, SecurityPallet, UtilFuncs, VaultId, VaultRegistryPallet,
     H256,
 };
@@ -1087,7 +1087,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_foreign_asset_collateral() {
-        let mock_bitcoin = MockBitcoin::default();
         let dummy_metadata = AssetMetadata {
             decimals: 10,
             location: None,

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -329,7 +329,7 @@ pub async fn metrics_handler() -> Result<impl Reply, Rejection> {
 }
 
 fn raw_value_as_currency(value: u128, currency: CurrencyId) -> Result<f64, ServiceError<Error>> {
-    let scaling_factor = currency.inner()?.one() as f64;
+    let scaling_factor = currency.one()? as f64;
     Ok(value as f64 / scaling_factor)
 }
 


### PR DESCRIPTION
- Bug 1: The current approach to building a metrics label out of a currecy (e.g. `vault_id.collateral_currency().inner()`) only has a `symbol()` entry defined for `CurrencyId::Token` types. It would call some function other than [the one](https://github.com/interlay/interbtc-clients/blob/95f96e6aaca33406f710f612d26af439cac426f8/runtime/src/assets.rs#L177) in the `RuntimeCurrencyInfo` trait. This results in metrics for foreign assets having an `_IBTC` label instead of `USDT_IBTC` (see the [discord user report](https://discord.com/channels/745259537707040778/991617172407337030/1091476550542688369)).
    - The fix removes the `.inner()` access and calls `.symbol()` directly on the `CurrencyId`. I also added a unit test for qtoken vaults to make sure we won't have the same problem.
- Bug 2: Metrics that read on-chain data fail to parse raw values of non-`Token` currency ids, because those don't have a `one()` method on their `inner()` value. I added `one()` to `RuntimeCurrencyInfo` and am calling it directly on `CurrencyId`.