### PR TITLE
fix: save rescanning progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5294,9 +5294,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
 
 [[package]]
 name = "libloading"
@@ -6891,9 +6891,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -10145,7 +10145,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -14971,6 +14971,7 @@ dependencies = [
  "mockall 0.8.3",
  "nonzero_ext",
  "parity-scale-codec",
+ "rocksdb",
  "runtime",
  "secp256k1 0.24.3",
  "serde",

--- a/vault/Cargo.toml
+++ b/vault/Cargo.toml
@@ -35,6 +35,8 @@ lazy_static = "1.4"
 governor = "0.5.0"
 nonzero_ext = "0.3.0"
 
+rocksdb = { version = "0.19.0", features = ["snappy"], default-features = false }
+
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.2.12", features = ["registry", "env-filter", "fmt"] }
 tracing-futures = { version = "0.2.5" }

--- a/vault/src/error.rs
+++ b/vault/src/error.rs
@@ -1,7 +1,11 @@
+use std::string::FromUtf8Error;
+
 use bitcoin::Error as BitcoinError;
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
+use rocksdb::Error as RocksDbError;
 use runtime::Error as RuntimeError;
+use serde_json::Error as SerdeJsonError;
 use thiserror::Error;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
@@ -32,6 +36,12 @@ pub enum Error {
     RuntimeError(#[from] RuntimeError),
     #[error("CodecError: {0}")]
     CodecError(#[from] CodecError),
+    #[error("DatabaseError: {0}")]
+    DatabaseError(#[from] RocksDbError),
+    #[error("SerdeJsonError: {0}")]
+    SerdeJsonError(#[from] SerdeJsonError),
+    #[error("FromUtf8Error: {0}")]
+    FromUtf8Error(#[from] FromUtf8Error),
     #[error("BroadcastStreamRecvError: {0}")]
     BroadcastStreamRecvError(#[from] BroadcastStreamRecvError),
 }

--- a/vault/src/main.rs
+++ b/vault/src/main.rs
@@ -164,6 +164,12 @@ async fn start() -> Result<(), ServiceError<Error>> {
     let (pair, wallet_name) = opts.account_info.get_key_pair()?;
     let signer = InterBtcSigner::new(pair);
 
+    let db_path = opts
+        .vault
+        .db_path
+        .clone()
+        .unwrap_or(format!("{}.db", wallet_name.clone()));
+
     let vault_connection_manager = ConnectionManager::new(
         signer.clone(),
         Some(wallet_name.to_string()),
@@ -173,6 +179,7 @@ async fn start() -> Result<(), ServiceError<Error>> {
         opts.monitoring.clone(),
         opts.vault,
         increment_restart_counter,
+        db_path,
     );
 
     if !opts.monitoring.no_prometheus {

--- a/vault/tests/vault_integration_tests.rs
+++ b/vault/tests/vault_integration_tests.rs
@@ -63,7 +63,12 @@ async fn test_redeem_succeeds() {
 
         let btc_rpcs = vec![(vault_id.clone(), btc_rpc.clone())].into_iter().collect();
         let btc_rpc_master_wallet = btc_rpc.clone();
-        let vault_id_manager = VaultIdManager::from_map(vault_provider.clone(), btc_rpc_master_wallet, btc_rpcs);
+        let vault_id_manager = VaultIdManager::from_map(
+            vault_provider.clone(),
+            btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_redeem_succeeds",
+        );
 
         let issue_amount = 100000;
         let vault_collateral =
@@ -126,8 +131,12 @@ async fn test_replace_succeeds() {
 
         let btc_rpcs = vec![(new_vault_id.clone(), btc_rpc.clone())].into_iter().collect();
         let new_btc_rpc_master_wallet = btc_rpc.clone();
-        let _vault_id_manager =
-            VaultIdManager::from_map(new_vault_provider.clone(), new_btc_rpc_master_wallet, btc_rpcs);
+        let _vault_id_manager = VaultIdManager::from_map(
+            new_vault_provider.clone(),
+            new_btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_replace_succeeds1",
+        );
         let btc_rpcs = vec![
             (old_vault_id.clone(), btc_rpc.clone()),
             (new_vault_id.clone(), btc_rpc.clone()),
@@ -135,8 +144,12 @@ async fn test_replace_succeeds() {
         .into_iter()
         .collect();
         let old_btc_rpc_master_wallet = btc_rpc.clone();
-        let vault_id_manager =
-            VaultIdManager::from_map(old_vault_provider.clone(), old_btc_rpc_master_wallet, btc_rpcs);
+        let vault_id_manager = VaultIdManager::from_map(
+            old_vault_provider.clone(),
+            old_btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_replace_succeeds2",
+        );
 
         let issue_amount = 100000;
         let vault_collateral = get_required_vault_collateral_for_issue(
@@ -303,8 +316,12 @@ async fn test_cancellation_succeeds() {
 
         let btc_rpcs = vec![(new_vault_id.clone(), btc_rpc.clone())].into_iter().collect();
         let new_btc_rpc_master_wallet = btc_rpc.clone();
-        let vault_id_manager =
-            VaultIdManager::from_map(new_vault_provider.clone(), new_btc_rpc_master_wallet, btc_rpcs);
+        let vault_id_manager = VaultIdManager::from_map(
+            new_vault_provider.clone(),
+            new_btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_cancellation_succeeds",
+        );
 
         let issue_amount = 100000;
         let vault_collateral = get_required_vault_collateral_for_issue(
@@ -565,7 +582,12 @@ async fn test_automatic_issue_execution_succeeds() {
 
         let btc_rpcs = vec![(vault2_id.clone(), btc_rpc.clone())].into_iter().collect();
         let btc_rpc_master_wallet = btc_rpc.clone();
-        let vault_id_manager = VaultIdManager::from_map(vault2_provider.clone(), btc_rpc_master_wallet, btc_rpcs);
+        let vault_id_manager = VaultIdManager::from_map(
+            vault2_provider.clone(),
+            btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_automatic_issue_execution_succeeds",
+        );
 
         let issue_amount = 100000;
         let vault_collateral =
@@ -658,7 +680,12 @@ async fn test_automatic_issue_execution_succeeds_with_big_transaction() {
 
         let btc_rpcs = vec![(vault2_id.clone(), btc_rpc.clone())].into_iter().collect();
         let btc_rpc_master_wallet = btc_rpc.clone();
-        let vault_id_manager = VaultIdManager::from_map(vault2_provider.clone(), btc_rpc_master_wallet, btc_rpcs);
+        let vault_id_manager = VaultIdManager::from_map(
+            vault2_provider.clone(),
+            btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_automatic_issue_execution_succeeds_with_big_transaction",
+        );
 
         let issue_amount = 100000;
         let vault_collateral =
@@ -740,7 +767,12 @@ async fn test_execute_open_requests_succeeds() {
 
         let btc_rpcs = vec![(vault_id.clone(), btc_rpc.clone())].into_iter().collect();
         let btc_rpc_master_wallet = btc_rpc.clone();
-        let vault_id_manager = VaultIdManager::from_map(vault_provider.clone(), btc_rpc_master_wallet, btc_rpcs);
+        let vault_id_manager = VaultIdManager::from_map(
+            vault_provider.clone(),
+            btc_rpc_master_wallet,
+            btc_rpcs,
+            "test_execute_open_requests_succeeds",
+        );
 
         let issue_amount = 100000;
         let vault_collateral =
@@ -1137,7 +1169,12 @@ mod test_with_bitcoind {
             // setup vault id manager
             let btc_rpcs = vec![(vault_id.clone(), btc_rpc.clone())].into_iter().collect();
             let btc_rpc_master_wallet = btc_rpc.clone();
-            let vault_id_manager = VaultIdManager::from_map(vault_provider.clone(), btc_rpc_master_wallet, btc_rpcs);
+            let vault_id_manager = VaultIdManager::from_map(
+                vault_provider.clone(),
+                btc_rpc_master_wallet,
+                btc_rpcs,
+                "test_automatic_rbf_succeeds",
+            );
 
             let issue_amount = 100000;
             let vault_collateral =


### PR DESCRIPTION
To address https://github.com/interlay/interbtc-clients/issues/471 .

Note that I went with another approach - rather than storing data in a hacky way inside the bitcoin wallet, I store it in a rocksdb (since we'll be stateful anyway with https://github.com/interlay/interbtc-clients/pull/246). I wrote it in such a way that the database can be removed without any bad side-effects: it will just rescan everything again. This means that users don't necessarily have to copy over the database when migrating their vaults to other servers