### PR TITLE
refactor: better caching, optional auth check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 event-logs
 faucet/kv
 keyfile.json
+config.json
 .deploy/monitoring/data
 .deploy/monitoring/prometheus
 .deploy/monitoring/alertmanager

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "hex",
  "jsonrpc-http-server",
  "kv",
+ "lazy_static",
  "log 0.4.18",
  "parity-scale-codec",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3052,6 +3052,7 @@ dependencies = [
  "kv",
  "log 0.4.18",
  "parity-scale-codec",
+ "reqwest",
  "runtime",
  "serde",
  "serde_json",
@@ -3059,6 +3060,7 @@ dependencies = [
  "sp-keyring 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
+ "url 2.3.1",
 ]
 
 [[package]]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -31,6 +31,7 @@ kv = { version = "0.22.0", features = ["json-value"] }
 async-trait = "0.1.40"
 futures = "0.3.5"
 git-version = "0.3.4"
+lazy_static = "1.4.0"
 
 reqwest = "0.11.11"
 url = "2.2.2"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -32,6 +32,9 @@ async-trait = "0.1.40"
 futures = "0.3.5"
 git-version = "0.3.4"
 
+reqwest = "0.11.11"
+url = "2.2.2"
+
 # Workspace dependencies
 runtime = { path = "../runtime" }
 service = { path = "../service" }

--- a/faucet/src/error.rs
+++ b/faucet/src/error.rs
@@ -1,13 +1,15 @@
 #![allow(clippy::enum_variant_names)]
 
-use chrono::ParseError;
+use chrono::ParseError as ChronoParseError;
 use jsonrpc_http_server::jsonrpc_core::Error as JsonRpcError;
 use kv::Error as KvError;
 use parity_scale_codec::Error as CodecError;
+use reqwest::Error as ReqwestError;
 use runtime::Error as RuntimeError;
 use serde_json::Error as SerdeJsonError;
 use std::{io::Error as IoError, net::AddrParseError};
 use thiserror::Error;
+use url::ParseError as UrlParseError;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -21,16 +23,23 @@ pub enum Error {
     AddrParseError(#[from] AddrParseError),
     #[error("Kv store error: {0}")]
     KvError(#[from] KvError),
+    #[error("ReqwestError: {0}")]
+    ReqwestError(#[from] ReqwestError),
+    #[error("UrlParseError: {0}")]
+    UrlParseError(#[from] UrlParseError),
     #[error("Error parsing datetime string: {0}")]
-    DatetimeParsingError(#[from] ParseError),
+    DatetimeParsingError(#[from] ChronoParseError),
+    #[error("IoError: {0}")]
+    IoError(#[from] IoError),
+    #[error("SerdeJsonError: {0}")]
+    SerdeJsonError(#[from] SerdeJsonError),
+
     #[error("Requester balance already sufficient")]
     AccountBalanceExceedsMaximum,
     #[error("Requester was recently funded")]
     AccountAlreadyFunded,
     #[error("Mathematical operation error")]
     MathError,
-    #[error("IoError: {0}")]
-    IoError(#[from] IoError),
-    #[error("SerdeJsonError: {0}")]
-    SerdeJsonError(#[from] SerdeJsonError),
+    #[error("Terms and conditions not signed")]
+    SignatureMissing,
 }

--- a/faucet/src/lib.rs
+++ b/faucet/src/lib.rs
@@ -1,10 +1,12 @@
 use parity_scale_codec::{Decode, Encode};
 use serde::Deserialize;
+
 #[derive(Deserialize, Debug, Clone, Encode, Decode)]
 pub struct AllowanceAmount {
     pub symbol: String,
     pub amount: u128,
 }
+
 impl AllowanceAmount {
     pub fn new(symbol: String, amount: u128) -> Self {
         Self { symbol, amount }

--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -40,6 +40,7 @@ pub struct AllowanceConfig {
     pub faucet_cooldown_hours: i64,
     pub user_allowances: Allowance,
     pub vault_allowances: Allowance,
+    pub auth_url: Option<String>,
 }
 
 impl AllowanceConfig {
@@ -54,6 +55,7 @@ impl AllowanceConfig {
             faucet_cooldown_hours,
             user_allowances,
             vault_allowances,
+            auth_url: None,
         }
     }
 }

--- a/runtime/src/error.rs
+++ b/runtime/src/error.rs
@@ -108,6 +108,13 @@ impl From<module_bitcoin::Error> for Error {
 }
 
 impl Error {
+    pub fn is_any_module_err(&self) -> bool {
+        matches!(
+            self,
+            Error::SubxtRuntimeError(SubxtError::Runtime(DispatchError::Module(_))),
+        )
+    }
+
     fn is_module_err(&self, pallet_name: &str, error_name: &str) -> bool {
         matches!(
             self,

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -748,7 +748,7 @@ mod tests {
             async fn get_free_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
             async fn get_reserved_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
             async fn get_reserved_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
-            async fn transfer_to(&self, recipient: &AccountId, amount: u128, currency_id: CurrencyId) -> Result<(), RuntimeError>;
+            async fn transfer_to(&self, recipient: &AccountId, amounts: Vec<(u128, CurrencyId)>) -> Result<(), RuntimeError>;
         }
 
         #[async_trait]

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -344,7 +344,7 @@ mod tests {
         async fn get_free_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
         async fn get_reserved_balance(&self, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
         async fn get_reserved_balance_for_id(&self, id: AccountId, currency_id: CurrencyId) -> Result<Balance, RuntimeError>;
-        async fn transfer_to(&self, recipient: &AccountId, amount: u128, currency_id: CurrencyId) -> Result<(), RuntimeError>;         }
+        async fn transfer_to(&self, recipient: &AccountId, amounts: Vec<(u128, CurrencyId)>) -> Result<(), RuntimeError>;         }
     }
 
     impl Clone for MockProvider {


### PR DESCRIPTION
Closes https://github.com/interlay/interbtc-clients/issues/478

- Flush data to disk
- Cache claim before transfer, revert on error
- Check T&Cs have been signed if `auth_url` set

Manually tested to avoid spending too much time on this right now before launch setting up mocks, etc.. The tests are anyway *very* slow so I would like to spend time refactoring this code anyway. It would also be nice to do away with the encoded input parameter to simplify manual testing.