### PR TITLE
chore: upgrade to docker compose v2

### DIFF
--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -172,7 +172,8 @@ pub async fn with_timeout<T: Future>(future: T, duration: Duration) -> T::Output
 }
 
 pub async fn start_chain() -> std::io::Result<Child> {
-    let _stop_previous_instance = Command::new("docker-compose")
+    let _stop_previous_instance = Command::new("docker")
+        .arg("compose")
         .arg("rm")
         .arg("-v")
         .arg("-s")

--- a/scripts/run_parachain_node.sh
+++ b/scripts/run_parachain_node.sh
@@ -4,4 +4,4 @@
 cd ..
 
 # Start parachain instance
-docker-compose up -d interbtc
+docker compose up -d interbtc


### PR DESCRIPTION
`docker-compose` stopped receiving updates, see https://docs.docker.com/compose/migrate/ .
This migrates the tests to use v2, which is `docker compose` rather than `docker-compose`. The CI still uses v1.

I had to setup my docker to allow non-root users access. To be more safe, I switched to [rootless docker](https://docs.docker.com/engine/security/rootless/) which I installed with [these instructions](https://www.liquidweb.com/kb/how-to-docker-rootless-containers/). I then installed the docker compose plugin based on the steps [here](https://docs.docker.com/engine/security/rootless/).



 