### PR TITLE
fix: migration for pruned nodes

### DIFF
--- a/bitcoin/src/electrs/types.rs
+++ b/bitcoin/src/electrs/types.rs
@@ -15,7 +15,7 @@ pub struct TransactionStatus {
 }
 
 // https://github.com/Blockstream/electrs/blob/adedee15f1fe460398a7045b292604df2161adc0/src/rest.rs#L167-L189
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct TxInValue {
     pub txid: Txid,
     pub vout: u32,
@@ -33,7 +33,7 @@ pub struct TxInValue {
 }
 
 // https://github.com/Blockstream/electrs/blob/adedee15f1fe460398a7045b292604df2161adc0/src/rest.rs#L239-L270
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct TxOutValue {
     pub scriptpubkey: ScriptBuf,
     pub scriptpubkey_asm: String,

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -469,6 +469,11 @@ impl BitcoinCore {
 
             // Make sure signing is successful
             if signed_funded_raw_tx.errors.is_some() {
+                log::warn!(
+                    "Received bitcoin funding errors (complete={}): {:?}",
+                    signed_funded_raw_tx.complete,
+                    signed_funded_raw_tx.errors
+                );
                 return Err(Error::TransactionSigningError);
             }
 
@@ -1092,7 +1097,7 @@ impl BitcoinCoreApi for BitcoinCore {
             // filter to only import
             // a) payments in the blockchain (not in mempool), and
             // b) payments TO the address (as bitcoin core will already know about transactions spending FROM it)
-            let confirmed_payments_to = all_transactions.into_iter().filter(|tx| {
+            let confirmed_payments_to = all_transactions.iter().filter(|tx| {
                 if let Some(status) = &tx.status {
                     if !status.confirmed {
                         return false;
@@ -1112,6 +1117,24 @@ impl BitcoinCoreApi for BitcoinCore {
                     "importprunedfunds",
                     &[serde_json::to_value(raw_tx)?, serde_json::to_value(raw_merkle_proof)?],
                 )?;
+            }
+            // TODO: remove this migration after the next runtime upgrade
+            // filter to remove spent funds, the previous wallet migration caused
+            // signing failures for pruned nodes because they tried to double spend
+            let confirmed_payments_from = all_transactions.iter().filter(|tx| {
+                if let Some(status) = &tx.status {
+                    if !status.confirmed {
+                        return false;
+                    }
+                };
+                tx.vin
+                    .iter()
+                    .filter_map(|input| input.prevout.clone())
+                    .any(|output| matches!(&output.scriptpubkey_address, Some(addr) if addr == &address))
+            });
+            for transaction in confirmed_payments_from {
+                self.rpc
+                    .call("removeprunedfunds", &[serde_json::to_value(transaction.txid)?])?;
             }
         }
         Ok(())


### PR DESCRIPTION
Succeeds https://github.com/interlay/interbtc-clients/pull/516

Fixes an issue with the migration when using a pruned bitcoin core node, because the shared wallet doesn't know which imported funds have been spent we need to manually remove those.