### PR TITLE
refactor: get largest payment

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -1160,7 +1160,7 @@ impl BitcoinCoreApi for BitcoinCore {
 pub trait TransactionExt {
     fn get_op_return(&self) -> Option<H256>;
     fn get_op_return_bytes(&self) -> Option<[u8; 34]>;
-    fn get_payment_amount_to(&self, dest: Payload) -> Option<u64>;
+    fn get_largest_payment_amount_to(&self, dest: Payload) -> Option<u64>;
     fn extract_output_addresses(&self) -> Vec<Payload>;
     fn extract_indexed_output_addresses(&self) -> Vec<(usize, Payload)>;
     fn extract_return_to_self_address(&self, destination: &Payload) -> Result<Option<(usize, Payload)>, Error>;
@@ -1187,15 +1187,18 @@ impl TransactionExt for Transaction {
     }
 
     /// Get the amount of btc that self sent to `dest`, if any
-    fn get_payment_amount_to(&self, dest: Payload) -> Option<u64> {
-        self.output.iter().find_map(|uxto| {
-            let payload = Payload::from_script(&uxto.script_pubkey).ok()?;
-            if payload == dest {
-                Some(uxto.value)
-            } else {
-                None
-            }
-        })
+    fn get_largest_payment_amount_to(&self, dest: Payload) -> Option<u64> {
+        self.output
+            .iter()
+            .filter_map(|uxto| {
+                let payload = Payload::from_script(&uxto.script_pubkey).ok()?;
+                if payload == dest {
+                    Some(uxto.value)
+                } else {
+                    None
+                }
+            })
+            .max()
     }
 
     /// return the addresses that are used as outputs with non-zero value in this transaction

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -656,7 +656,7 @@ pub async fn execute_open_requests(
 fn get_request_for_btc_tx(tx: &Transaction, hash_map: &HashMap<H256, Request>) -> Option<Request> {
     let hash = tx.get_op_return()?;
     let request = hash_map.get(&hash)?;
-    let paid_amount = tx.get_payment_amount_to(request.btc_address.to_payload().ok()?)?;
+    let paid_amount = tx.get_largest_payment_amount_to(request.btc_address.to_payload().ok()?)?;
     if paid_amount as u128 >= request.amount {
         Some(request.clone())
     } else {

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -247,7 +247,7 @@ async fn process_transaction_and_execute_issue(
             return Ok(());
         };
         // tx has output to address
-        match transaction.get_payment_amount_to(payload) {
+        match transaction.get_largest_payment_amount_to(payload) {
             None => {
                 // this should never happen, so use WARN
                 tracing::warn!(


### PR DESCRIPTION
Minor fix; we may skip a valid payment if a smaller amount is also sent to the target address in the same transaction.