### PR TITLE
fix: sweep funds into shared wallet

### DIFF
--- a/bitcoin/src/electrs/mod.rs
+++ b/bitcoin/src/electrs/mod.rs
@@ -105,6 +105,11 @@ impl ElectrsClient {
         Ok(ret)
     }
 
+    pub async fn is_tx_output_spent(&self, txid: &Txid, vout: u32) -> Result<bool, Error> {
+        let spending_value: SpendingValue = self.get_and_decode(&format!("/tx/{txid}/outspend/{vout}")).await?;
+        Ok(spending_value.spent)
+    }
+
     pub async fn get_blocks_tip_height(&self) -> Result<u32, Error> {
         Ok(self.get("/blocks/tip/height").await?.parse()?)
     }

--- a/bitcoin/src/electrs/types.rs
+++ b/bitcoin/src/electrs/types.rs
@@ -66,3 +66,15 @@ pub struct UtxoValue {
     pub status: TransactionStatus,
     pub value: u64,
 }
+
+// https://github.com/Blockstream/electrs/blob/adedee15f1fe460398a7045b292604df2161adc0/src/rest.rs#L448-L457
+#[derive(Deserialize)]
+pub struct SpendingValue {
+    pub spent: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub txid: Option<Txid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vin: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<TransactionStatus>,
+}

--- a/bitcoin/src/iter.rs
+++ b/bitcoin/src/iter.rs
@@ -253,7 +253,7 @@ mod tests {
                 fee_rate: SatPerVbyte,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, Error>;
-            async fn sweep_funds(&self, address: Address) -> Result<Txid, Error>;
+            async fn sweep_funds(&self, address: Address) -> Result<(), Error>;
             async fn create_or_load_wallet(&self) -> Result<(), Error>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error>;
             async fn rescan_electrs_for_addresses(

--- a/bitcoin/src/iter.rs
+++ b/bitcoin/src/iter.rs
@@ -214,6 +214,8 @@ mod tests {
             async fn get_proof(&self, txid: Txid, block_hash: &BlockHash) -> Result<Vec<u8>, Error>;
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, Error>;
             async fn get_new_address(&self) -> Result<Address, Error>;
+            async fn get_new_sweep_address(&self) -> Result<Address, Error>;
+            async fn get_last_sweep_height(&self) -> Result<Option<u32>, Error>;
             async fn get_new_public_key(&self) -> Result<PublicKey, Error>;
             fn dump_private_key(&self, address: &Address) -> Result<PrivateKey, Error>;
             fn import_private_key(&self, private_key: &PrivateKey, is_derivation_key: bool) -> Result<(), Error>;
@@ -251,6 +253,7 @@ mod tests {
                 fee_rate: SatPerVbyte,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, Error>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, Error>;
             async fn create_or_load_wallet(&self) -> Result<(), Error>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error>;
             async fn rescan_electrs_for_addresses(

--- a/bitcoin/src/iter.rs
+++ b/bitcoin/src/iter.rs
@@ -253,7 +253,7 @@ mod tests {
                 fee_rate: SatPerVbyte,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, Error>;
-            async fn sweep_funds(&self, address: Address) -> Result<(), Error>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, Error>;
             async fn create_or_load_wallet(&self) -> Result<(), Error>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), Error>;
             async fn rescan_electrs_for_addresses(

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -1067,6 +1067,7 @@ impl BitcoinCoreApi for BitcoinCore {
 
         for entry in unspent {
             if self.electrs_client.is_tx_output_spent(&entry.txid, entry.vout).await? {
+                log::info!("{}:{} already spent", entry.txid, entry.vout);
                 // skip if already spent
                 continue;
             }
@@ -1077,6 +1078,8 @@ impl BitcoinCoreApi for BitcoinCore {
                 sequence: None,
             })
         }
+
+        log::info!("Sweeping {} from {} utxos", amount, utxos.len());
 
         let mut outputs = serde_json::Map::<String, serde_json::Value>::new();
         outputs.insert(address.to_string(), serde_json::Value::from(amount.to_btc()));

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -1064,7 +1064,7 @@ impl BitcoinCoreApi for BitcoinCore {
     }
 
     async fn sweep_funds(&self, address: Address) -> Result<Txid, Error> {
-        let unspent = self.rpc.list_unspent(None, None, None, None, None)?;
+        let unspent = self.rpc.list_unspent(Some(0), None, None, None, None)?;
 
         let mut amount = Amount::ZERO;
         let mut utxos = Vec::<json::CreateRawTransactionInput>::new();

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -213,7 +213,7 @@ pub trait BitcoinCoreApi {
         num_confirmations: u32,
     ) -> Result<TransactionMetadata, Error>;
 
-    async fn sweep_funds(&self, address: Address) -> Result<(), Error>;
+    async fn sweep_funds(&self, address: Address) -> Result<Txid, Error>;
 
     async fn create_or_load_wallet(&self) -> Result<(), Error>;
 
@@ -1063,7 +1063,7 @@ impl BitcoinCoreApi for BitcoinCore {
             .await?)
     }
 
-    async fn sweep_funds(&self, address: Address) -> Result<(), Error> {
+    async fn sweep_funds(&self, address: Address) -> Result<Txid, Error> {
         let unspent = self.rpc.list_unspent(None, None, None, None, None)?;
 
         let mut amount = Amount::ZERO;
@@ -1118,10 +1118,9 @@ impl BitcoinCoreApi for BitcoinCore {
 
         let transaction = signed_funded_raw_tx.transaction()?;
         let txid = self.rpc.send_raw_transaction(&transaction)?;
-
         log::info!("Sent sweep tx: {txid}");
 
-        Ok(())
+        Ok(txid)
     }
 
     /// Create or load a wallet on Bitcoin Core.

--- a/bitcoin/src/light/mod.rs
+++ b/bitcoin/src/light/mod.rs
@@ -168,6 +168,14 @@ impl BitcoinCoreApi for BitcoinLight {
         Ok(self.get_change_address()?)
     }
 
+    async fn get_new_sweep_address(&self) -> Result<Address, BitcoinError> {
+        Ok(self.get_change_address()?)
+    }
+
+    async fn get_last_sweep_height(&self) -> Result<Option<u32>, BitcoinError> {
+        Ok(None)
+    }
+
     async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError> {
         Ok(self.private_key.public_key(&self.secp_ctx))
     }
@@ -329,6 +337,10 @@ impl BitcoinCoreApi for BitcoinLight {
         Ok(self
             .wait_for_transaction_metadata(txid, num_confirmations, None, true)
             .await?)
+    }
+
+    async fn sweep_funds(&self, _address: Address) -> Result<Txid, BitcoinError> {
+        Ok(Txid::all_zeros())
     }
 
     async fn create_or_load_wallet(&self) -> Result<(), BitcoinError> {

--- a/bitcoin/src/light/mod.rs
+++ b/bitcoin/src/light/mod.rs
@@ -339,8 +339,8 @@ impl BitcoinCoreApi for BitcoinLight {
             .await?)
     }
 
-    async fn sweep_funds(&self, _address: Address) -> Result<(), BitcoinError> {
-        Ok(())
+    async fn sweep_funds(&self, _address: Address) -> Result<Txid, BitcoinError> {
+        Ok(Txid::all_zeros())
     }
 
     async fn create_or_load_wallet(&self) -> Result<(), BitcoinError> {

--- a/bitcoin/src/light/mod.rs
+++ b/bitcoin/src/light/mod.rs
@@ -339,8 +339,8 @@ impl BitcoinCoreApi for BitcoinLight {
             .await?)
     }
 
-    async fn sweep_funds(&self, _address: Address) -> Result<Txid, BitcoinError> {
-        Ok(Txid::all_zeros())
+    async fn sweep_funds(&self, _address: Address) -> Result<(), BitcoinError> {
+        Ok(())
     }
 
     async fn create_or_load_wallet(&self) -> Result<(), BitcoinError> {

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -405,6 +405,15 @@ impl BitcoinCoreApi for MockBitcoinCore {
         let address = BtcAddress::P2PKH(H160::from(bytes));
         Ok(address.to_address(Network::Regtest)?)
     }
+
+    async fn get_new_sweep_address(&self) -> Result<Address, BitcoinError> {
+        self.get_new_address().await
+    }
+
+    async fn get_last_sweep_height(&self) -> Result<Option<u32>, BitcoinError> {
+        Ok(None)
+    }
+
     async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError> {
         let secp = Secp256k1::new();
         let raw_secret_key: [u8; SECRET_KEY_SIZE] = thread_rng().gen();
@@ -514,6 +523,9 @@ impl BitcoinCoreApi for MockBitcoinCore {
             .unwrap();
         Ok(metadata)
     }
+    async fn sweep_funds(&self, _address: Address) -> Result<Txid, BitcoinError> {
+        Ok(Txid::all_zeros())
+    }
     async fn create_or_load_wallet(&self) -> Result<(), BitcoinError> {
         Ok(())
     }
@@ -524,6 +536,7 @@ impl BitcoinCoreApi for MockBitcoinCore {
     async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError> {
         Ok(())
     }
+
     fn get_utxo_count(&self) -> Result<usize, BitcoinError> {
         Ok(0)
     }

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -523,8 +523,8 @@ impl BitcoinCoreApi for MockBitcoinCore {
             .unwrap();
         Ok(metadata)
     }
-    async fn sweep_funds(&self, _address: Address) -> Result<(), BitcoinError> {
-        Ok(())
+    async fn sweep_funds(&self, _address: Address) -> Result<Txid, BitcoinError> {
+        Ok(Txid::all_zeros())
     }
     async fn create_or_load_wallet(&self) -> Result<(), BitcoinError> {
         Ok(())

--- a/runtime/src/integration/bitcoin_simulator.rs
+++ b/runtime/src/integration/bitcoin_simulator.rs
@@ -523,8 +523,8 @@ impl BitcoinCoreApi for MockBitcoinCore {
             .unwrap();
         Ok(metadata)
     }
-    async fn sweep_funds(&self, _address: Address) -> Result<Txid, BitcoinError> {
-        Ok(Txid::all_zeros())
+    async fn sweep_funds(&self, _address: Address) -> Result<(), BitcoinError> {
+        Ok(())
     }
     async fn create_or_load_wallet(&self) -> Result<(), BitcoinError> {
         Ok(())

--- a/vault/src/connection_manager.rs
+++ b/vault/src/connection_manager.rs
@@ -28,6 +28,7 @@ pub trait Service<Config> {
         btc_parachain: BtcParachain,
         bitcoin_core_master: DynBitcoinCoreApi,
         bitcoin_core_shared: DynBitcoinCoreApi,
+        bitcoin_core_shared_v2: DynBitcoinCoreApi,
         config: Config,
         monitoring_config: MonitoringConfig,
         shutdown: ShutdownSender,
@@ -107,6 +108,9 @@ impl<Config: Clone + Send + 'static, F: Fn()> ConnectionManager<Config, F> {
             let bitcoin_core_shared =
                 config_copy.new_client_with_network(Some(format!("{prefix}-shared")), network_copy)?;
             bitcoin_core_shared.create_or_load_wallet().await?;
+            let bitcoin_core_shared_v2 =
+                config_copy.new_client_with_network(Some(format!("{prefix}-shared-v2")), network_copy)?;
+            bitcoin_core_shared_v2.create_or_load_wallet().await?;
 
             let constructor = move |vault_id: VaultId| {
                 let collateral_currency: CurrencyId = vault_id.collateral_currency();
@@ -128,6 +132,7 @@ impl<Config: Clone + Send + 'static, F: Fn()> ConnectionManager<Config, F> {
                 btc_parachain,
                 bitcoin_core_master,
                 bitcoin_core_shared,
+                bitcoin_core_shared_v2,
                 config,
                 self.monitoring_config.clone(),
                 shutdown_tx.clone(),

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -822,7 +822,7 @@ mod tests {
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32, block_hash: Option<BlockHash>, is_wallet: bool) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
             async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<(), BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -809,6 +809,8 @@ mod tests {
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
             async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
             async fn get_new_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_new_sweep_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_last_sweep_height(&self) -> Result<Option<u32>, BitcoinError>;
             async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError>;
             fn dump_private_key(&self, address: &Address) -> Result<PrivateKey, BitcoinError>;
             fn import_private_key(&self, private_key: &PrivateKey, is_derivation_key: bool) -> Result<(), BitcoinError>;
@@ -820,6 +822,7 @@ mod tests {
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32, block_hash: Option<BlockHash>, is_wallet: bool) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
             async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/execution.rs
+++ b/vault/src/execution.rs
@@ -822,7 +822,7 @@ mod tests {
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32, block_hash: Option<BlockHash>, is_wallet: bool) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
             async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn sweep_funds(&self, address: Address) -> Result<(), BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -86,7 +86,7 @@ struct RescanStatus {
 impl RescanStatus {
     // there was a bug pre-v2 that set rescanning status to an invalid range.
     // by changing the keyname we effectively force a reset
-    const KEY: &str = "rescan-status-v3";
+    const KEY: &str = "rescan-status-v4";
     fn update(&mut self, mut issues: Vec<InterBtcIssueRequest>, current_bitcoin_height: usize) {
         // Only look at issues that haven't been processed yet
         issues.retain(|issue| issue.opentime > self.newest_issue_height);

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -166,7 +166,7 @@ pub async fn add_keys_from_past_issue_request(
     // privkey
     let btc_end_height = bitcoin_core.get_block_count().await? as usize;
     let btc_pruned_start_height = bitcoin_core.get_pruned_height().await? as usize;
-    let btc_max_sweep_height = bitcoin_core.get_last_sweep_height().await?;
+    let btc_last_sweep_height = bitcoin_core.get_last_sweep_height().await?;
 
     let issues = issue_requests.clone().into_iter().map(|(_key, issue)| issue).collect();
     scanning_status.update(issues, btc_end_height);
@@ -184,7 +184,7 @@ pub async fn add_keys_from_past_issue_request(
                     .into_iter()
                     .filter_map(|(_, request)| {
                         // only import if address is AFTER last sweep height and BEFORE current pruning height
-                        if btc_max_sweep_height.is_some_and(|sweep_height| request.btc_height > sweep_height)
+                        if btc_last_sweep_height.map_or(true, |sweep_height| request.btc_height > sweep_height)
                             && (request.btc_height as usize) < btc_pruned_start_height
                         {
                             Some(request.btc_address.to_address(bitcoin_core.network()).ok()?)

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -144,7 +144,84 @@ impl RescanStatus {
     }
 }
 
-pub async fn add_keys_from_past_issue_request(
+pub async fn add_keys_from_past_issue_request_old(
+    bitcoin_core: &DynBitcoinCoreApi,
+    btc_parachain: &InterBtcParachain,
+    db: &DatabaseConfig,
+) -> Result<(), Error> {
+    let account_id = btc_parachain.get_account_id();
+    let mut scanning_status = RescanStatus::get(&account_id, db)?;
+    tracing::info!("Scanning: {scanning_status:?}");
+
+    let issue_requests = btc_parachain.get_vault_issue_requests(account_id.clone()).await?;
+
+    for (issue_id, request) in issue_requests.clone().into_iter() {
+        if let Err(e) = add_new_deposit_key(bitcoin_core, issue_id, request.btc_public_key).await {
+            tracing::error!("Failed to add deposit key #{}: {}", issue_id, e.to_string());
+        }
+    }
+
+    // read height only _after_ the last add_new_deposit_key. If a new block arrives
+    // while we rescan, bitcoin core will correctly recognize addressed associated with the
+    // privkey
+    let btc_end_height = bitcoin_core.get_block_count().await? as usize;
+    let btc_pruned_start_height = bitcoin_core.get_pruned_height().await? as usize;
+
+    let issues = issue_requests.clone().into_iter().map(|(_key, issue)| issue).collect();
+    scanning_status.update(issues, btc_end_height);
+
+    // use electrs to scan the portion that is not scannable by bitcoin core
+    if let Some((start, end)) = scanning_status.prune(btc_pruned_start_height) {
+        tracing::info!(
+            "Also checking electrs for issue requests between {} and {}...",
+            start,
+            end
+        );
+        bitcoin_core
+            .rescan_electrs_for_addresses(
+                issue_requests
+                    .into_iter()
+                    .filter_map(|(_, request)| {
+                        // only import if BEFORE current pruning height
+                        if (request.btc_height as usize) < btc_pruned_start_height {
+                            Some(request.btc_address.to_address(bitcoin_core.network()).ok()?)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect(),
+            )
+            .await?;
+    }
+
+    // save progress s.t. we don't rescan pruned range again if we crash now
+    scanning_status.store(account_id, db)?;
+
+    let mut chunk_size = 1;
+    // rescan the blockchain in chunks, so that we can save progress. The code below
+    // aims to have each chunk take about 10 seconds (arbitrarily chosen value).
+    while let Some((chunk_start, chunk_end)) = scanning_status.process_blocks(chunk_size) {
+        tracing::info!("Rescanning bitcoin chain from {} to {}...", chunk_start, chunk_end);
+
+        let start_time = Instant::now();
+
+        bitcoin_core.rescan_blockchain(chunk_start, chunk_end).await?;
+
+        // with the code below the rescan time should remain between 5 and 20 seconds
+        // after the first couple of rounds.
+        if start_time.elapsed() < Duration::from_secs(10) {
+            chunk_size = chunk_size.saturating_mul(2);
+        } else {
+            chunk_size = (chunk_size.checked_div(2).ok_or(Error::ArithmeticUnderflow)?).max(1);
+        }
+
+        scanning_status.store(account_id, db)?;
+    }
+
+    Ok(())
+}
+
+pub async fn add_keys_from_past_issue_request_new(
     bitcoin_core: &DynBitcoinCoreApi,
     btc_parachain: &InterBtcParachain,
     db: &DatabaseConfig,

--- a/vault/src/issue.rs
+++ b/vault/src/issue.rs
@@ -166,6 +166,7 @@ pub async fn add_keys_from_past_issue_request(
     // privkey
     let btc_end_height = bitcoin_core.get_block_count().await? as usize;
     let btc_pruned_start_height = bitcoin_core.get_pruned_height().await? as usize;
+    let btc_max_sweep_height = bitcoin_core.get_last_sweep_height().await?;
 
     let issues = issue_requests.clone().into_iter().map(|(_key, issue)| issue).collect();
     scanning_status.update(issues, btc_end_height);
@@ -182,7 +183,10 @@ pub async fn add_keys_from_past_issue_request(
                 issue_requests
                     .into_iter()
                     .filter_map(|(_, request)| {
-                        if (request.btc_height as usize) < btc_pruned_start_height {
+                        // only import if address is AFTER last sweep height and BEFORE current pruning height
+                        if btc_max_sweep_height.is_some_and(|sweep_height| request.btc_height > sweep_height)
+                            && (request.btc_height as usize) < btc_pruned_start_height
+                        {
                             Some(request.btc_address.to_address(bitcoin_core.network()).ok()?)
                         } else {
                             None

--- a/vault/src/lib.rs
+++ b/vault/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![feature(array_zip)]
+#![feature(is_some_and)]
 
 mod cancellation;
 mod cli;

--- a/vault/src/lib.rs
+++ b/vault/src/lib.rs
@@ -1,6 +1,5 @@
 #![recursion_limit = "256"]
 #![feature(array_zip)]
-#![feature(is_some_and)]
 
 mod cancellation;
 mod cli;

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -782,6 +782,8 @@ mod tests {
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
             async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
             async fn get_new_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_new_sweep_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_last_sweep_height(&self) -> Result<Option<u32>, BitcoinError>;
             async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError>;
             fn dump_private_key(&self, address: &Address) -> Result<PrivateKey, BitcoinError>;
             fn import_private_key(&self, private_key: &PrivateKey, is_derivation_key: bool) -> Result<(), BitcoinError>;
@@ -793,6 +795,7 @@ mod tests {
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32, block_hash: Option<BlockHash>, is_wallet: bool) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
             async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -795,7 +795,7 @@ mod tests {
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32, block_hash: Option<BlockHash>, is_wallet: bool) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
             async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn sweep_funds(&self, address: Address) -> Result<(), BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/metrics.rs
+++ b/vault/src/metrics.rs
@@ -795,7 +795,7 @@ mod tests {
             async fn wait_for_transaction_metadata(&self, txid: Txid, num_confirmations: u32, block_hash: Option<BlockHash>, is_wallet: bool) -> Result<TransactionMetadata, BitcoinError>;
             async fn create_and_send_transaction(&self, address: Address, sat: u64, fee_rate: SatPerVbyte, request_id: Option<H256>) -> Result<Txid, BitcoinError>;
             async fn send_to_address(&self, address: Address, sat: u64, request_id: Option<H256>, fee_rate: SatPerVbyte, num_confirmations: u32) -> Result<TransactionMetadata, BitcoinError>;
-            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<(), BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -285,7 +285,7 @@ mod tests {
                 fee_rate: SatPerVbyte,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, BitcoinError>;
-            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<(), BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -285,6 +285,7 @@ mod tests {
                 fee_rate: SatPerVbyte,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -285,7 +285,7 @@ mod tests {
                 fee_rate: SatPerVbyte,
                 num_confirmations: u32,
             ) -> Result<TransactionMetadata, BitcoinError>;
-            async fn sweep_funds(&self, address: Address) -> Result<(), BitcoinError>;
+            async fn sweep_funds(&self, address: Address) -> Result<Txid, BitcoinError>;
             async fn create_or_load_wallet(&self) -> Result<(), BitcoinError>;
             async fn rescan_blockchain(&self, start_height: usize, end_height: usize) -> Result<(), BitcoinError>;
             async fn rescan_electrs_for_addresses(&self, addresses: Vec<Address>) -> Result<(), BitcoinError>;

--- a/vault/src/replace.rs
+++ b/vault/src/replace.rs
@@ -249,6 +249,8 @@ mod tests {
             async fn get_block_hash(&self, height: u32) -> Result<BlockHash, BitcoinError>;
             async fn get_pruned_height(&self) -> Result<u64, BitcoinError>;
             async fn get_new_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_new_sweep_address(&self) -> Result<Address, BitcoinError>;
+            async fn get_last_sweep_height(&self) -> Result<Option<u32>, BitcoinError>;
             async fn get_new_public_key(&self) -> Result<PublicKey, BitcoinError>;
             fn dump_private_key(&self, address: &Address) -> Result<PrivateKey, BitcoinError>;
             fn import_private_key(&self, private_key: &PrivateKey, is_derivation_key: bool) -> Result<(), BitcoinError>;

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -305,6 +305,7 @@ impl VaultIdManager {
             Ok(private_key) => {
                 // TODO: remove this after the migration is complete
                 btc_rpc_shared.import_private_key(&private_key, true)?;
+                self.btc_rpc_shared_wallet_v2.import_private_key(&private_key, true)?;
             }
             Err(err) => {
                 tracing::error!("Could not find the derivation key in the bitcoin wallet");

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -215,6 +215,7 @@ pub struct VaultIdManager {
     btc_parachain: InterBtcParachain,
     btc_rpc_master_wallet: DynBitcoinCoreApi,
     pub(crate) btc_rpc_shared_wallet: DynBitcoinCoreApi,
+    pub(crate) btc_rpc_shared_wallet_v2: DynBitcoinCoreApi,
     // TODO: remove this
     #[allow(clippy::type_complexity)]
     constructor: Arc<Box<dyn Fn(VaultId) -> Result<DynBitcoinCoreApi, BitcoinError> + Send + Sync>>,
@@ -226,6 +227,7 @@ impl VaultIdManager {
         btc_parachain: InterBtcParachain,
         btc_rpc_master_wallet: DynBitcoinCoreApi,
         btc_rpc_shared_wallet: DynBitcoinCoreApi,
+        btc_rpc_shared_wallet_v2: DynBitcoinCoreApi,
         constructor: impl Fn(VaultId) -> Result<DynBitcoinCoreApi, BitcoinError> + Send + Sync + 'static,
         db_path: String,
     ) -> Self {
@@ -234,6 +236,7 @@ impl VaultIdManager {
             constructor: Arc::new(Box::new(constructor)),
             btc_rpc_master_wallet,
             btc_rpc_shared_wallet,
+            btc_rpc_shared_wallet_v2,
             btc_parachain,
             db: DatabaseConfig { path: db_path },
         }
@@ -244,6 +247,7 @@ impl VaultIdManager {
         btc_parachain: InterBtcParachain,
         btc_rpc_master_wallet: DynBitcoinCoreApi,
         btc_rpc_shared_wallet: DynBitcoinCoreApi,
+        btc_rpc_shared_wallet_v2: DynBitcoinCoreApi,
         map: HashMap<VaultId, DynBitcoinCoreApi>,
         db_path: &str,
     ) -> Self {
@@ -265,6 +269,7 @@ impl VaultIdManager {
             constructor: Arc::new(Box::new(|_| unimplemented!())),
             btc_rpc_master_wallet,
             btc_rpc_shared_wallet,
+            btc_rpc_shared_wallet_v2,
             btc_parachain,
             db: DatabaseConfig {
                 path: db_path.to_string(),
@@ -308,10 +313,9 @@ impl VaultIdManager {
         }
 
         tracing::info!("Merging wallet for {:?}", vault_id);
-        let all_addresses = btc_rpc.list_addresses()?;
         // issue keys should be imported separately but we need to iterate
         // through currency specific wallets to get change addresses
-        for address in &all_addresses {
+        for address in btc_rpc.list_addresses()? {
             tracing::info!("Found {:?}", address);
             // get private key from currency specific wallet
             let private_key = btc_rpc.dump_private_key(&address)?;
@@ -319,17 +323,11 @@ impl VaultIdManager {
             btc_rpc_shared.import_private_key(&private_key, false)?;
         }
 
-        if btc_rpc_shared.get_pruned_height().await? != 0 {
-            // rescan via electrs to import or remove change utxos
-            // this is required because pruned nodes cannot rescan themselves
-            btc_rpc_shared.rescan_electrs_for_addresses(all_addresses).await?;
-        }
-
         tracing::info!("Initializing metrics...");
         let metrics = PerCurrencyMetrics::new(&vault_id);
         let data = VaultData {
             vault_id: vault_id.clone(),
-            btc_rpc: btc_rpc_shared,
+            btc_rpc: self.btc_rpc_shared_wallet_v2.clone(),
             metrics: metrics.clone(),
         };
         PerCurrencyMetrics::initialize_values(self.btc_parachain.clone(), &data).await;
@@ -361,6 +359,23 @@ impl VaultIdManager {
                 }
             }
         }
+        Ok(())
+    }
+
+    async fn sweep_shared_wallet(&self) -> Result<(), Error> {
+        if self.btc_rpc_shared_wallet.get_pruned_height().await? == 0 {
+            // no need to sweep, full node can rescan
+            return Ok(());
+        } else if self.btc_rpc_shared_wallet_v2.get_last_sweep_height().await?.is_some() {
+            // already has sweep tx
+            return Ok(());
+        }
+
+        // sweep funds from shared wallet to shared-v2
+        let shared_v2_wallet_address = self.btc_rpc_shared_wallet_v2.get_new_sweep_address().await?;
+        let txid = self.btc_rpc_shared_wallet.sweep_funds(shared_v2_wallet_address).await?;
+        tracing::info!("Sent sweep tx: {txid}");
+
         Ok(())
     }
 
@@ -436,6 +451,7 @@ impl Service<VaultServiceConfig> for VaultService {
         btc_parachain: InterBtcParachain,
         btc_rpc_master_wallet: DynBitcoinCoreApi,
         btc_rpc_shared_wallet: DynBitcoinCoreApi,
+        btc_rpc_shared_wallet_v2: DynBitcoinCoreApi,
         config: VaultServiceConfig,
         monitoring_config: MonitoringConfig,
         shutdown: ShutdownSender,
@@ -446,6 +462,7 @@ impl Service<VaultServiceConfig> for VaultService {
             btc_parachain,
             btc_rpc_master_wallet,
             btc_rpc_shared_wallet,
+            btc_rpc_shared_wallet_v2,
             config,
             monitoring_config,
             shutdown,
@@ -520,6 +537,7 @@ impl VaultService {
         btc_parachain: InterBtcParachain,
         btc_rpc_master_wallet: DynBitcoinCoreApi,
         btc_rpc_shared_wallet: DynBitcoinCoreApi,
+        btc_rpc_shared_wallet_v2: DynBitcoinCoreApi,
         config: VaultServiceConfig,
         monitoring_config: MonitoringConfig,
         shutdown: ShutdownSender,
@@ -537,6 +555,7 @@ impl VaultService {
                 btc_parachain,
                 btc_rpc_master_wallet,
                 btc_rpc_shared_wallet,
+                btc_rpc_shared_wallet_v2,
                 constructor,
                 db_path,
             ),
@@ -650,6 +669,7 @@ impl VaultService {
 
         // purposefully _after_ maybe_register_vault and _before_ other calls
         self.vault_id_manager.fetch_vault_ids().await?;
+        self.vault_id_manager.sweep_shared_wallet().await?;
 
         tracing::info!("Adding keys from past issues...");
         issue::add_keys_from_past_issue_request(

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -376,11 +376,10 @@ impl VaultIdManager {
 
     // only run AFTER the separate currency wallet sweeps
     async fn sweep_shared_wallet(&self) -> Result<(), Error> {
-        if self.btc_rpc_shared_wallet.get_pruned_height().await? == 0 {
-            // no need to sweep, full node can rescan
-            return Ok(());
-        } else if self.btc_rpc_shared_wallet_v2.get_last_sweep_height().await?.is_some() {
-            // already has sweep tx
+        if self.btc_rpc_shared_wallet.get_pruned_height().await? == 0
+            || self.btc_rpc_shared_wallet_v2.get_last_sweep_height().await?.is_some()
+        {
+            // no need to sweep, full node can rescan or already has sweep tx
             return Ok(());
         }
 

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -455,6 +455,7 @@ impl VaultIdManager {
 pub struct VaultService {
     btc_parachain: InterBtcParachain,
     btc_rpc_master_wallet: DynBitcoinCoreApi,
+    btc_rpc_shared_wallet: DynBitcoinCoreApi,
     btc_rpc_shared_wallet_v2: DynBitcoinCoreApi,
     config: VaultServiceConfig,
     monitoring_config: MonitoringConfig,
@@ -567,6 +568,7 @@ impl VaultService {
         Self {
             btc_parachain: btc_parachain.clone(),
             btc_rpc_master_wallet: btc_rpc_master_wallet.clone(),
+            btc_rpc_shared_wallet: btc_rpc_shared_wallet.clone(),
             btc_rpc_shared_wallet_v2: btc_rpc_shared_wallet_v2.clone(),
             config,
             monitoring_config,
@@ -689,10 +691,17 @@ impl VaultService {
 
         // purposefully _after_ maybe_register_vault and _before_ other calls
         self.vault_id_manager.fetch_vault_ids().await?;
-        self.vault_id_manager.sweep_shared_wallet().await?;
 
         tracing::info!("Adding keys from past issues...");
-        issue::add_keys_from_past_issue_request(
+        issue::add_keys_from_past_issue_request_old(
+            &self.btc_rpc_shared_wallet,
+            &self.btc_parachain,
+            &self.vault_id_manager.db,
+        )
+        .await?;
+
+        self.vault_id_manager.sweep_shared_wallet().await?;
+        issue::add_keys_from_past_issue_request_new(
             &self.btc_rpc_shared_wallet_v2,
             &self.btc_parachain,
             &self.vault_id_manager.db,

--- a/vault/src/system.rs
+++ b/vault/src/system.rs
@@ -325,11 +325,14 @@ impl VaultIdManager {
         }
 
         // only sweep if using pruned node and there is no sweep tx yet to shared-v2
-        if btc_rpc_shared.get_pruned_height().await? != 0 && self.btc_rpc_shared_wallet_v2.get_last_sweep_height().await?.is_none() {
+        if btc_rpc_shared.get_pruned_height().await? != 0
+            && self.btc_rpc_shared_wallet_v2.get_last_sweep_height().await?.is_none()
+        {
             // sweep to old shared wallet which will then sweep again to the v2 wallet
             let shared_wallet_address = btc_rpc_shared.get_new_address().await?;
-            let txid = btc_rpc.sweep_funds(shared_wallet_address).await?;
-            tracing::info!("Sent sweep tx: {txid}");
+            if let Err(err) = btc_rpc.sweep_funds(shared_wallet_address).await {
+                tracing::error!("Could not sweep funds: {err}");
+            }
         }
 
         tracing::info!("Initializing metrics...");
@@ -382,8 +385,9 @@ impl VaultIdManager {
 
         // sweep funds from shared wallet to shared-v2
         let shared_v2_wallet_address = self.btc_rpc_shared_wallet_v2.get_new_sweep_address().await?;
-        let txid = self.btc_rpc_shared_wallet.sweep_funds(shared_v2_wallet_address).await?;
-        tracing::info!("Sent sweep tx: {txid}");
+        if let Err(err) = self.btc_rpc_shared_wallet.sweep_funds(shared_v2_wallet_address).await {
+            tracing::error!("Could not sweep funds: {err}");
+        }
 
         Ok(())
     }

--- a/vault/tests/vault_integration_tests.rs
+++ b/vault/tests/vault_integration_tests.rs
@@ -96,6 +96,7 @@ async fn test_redeem_succeeds() {
         let vault_id_manager = VaultIdManager::from_map(
             vault_provider.clone(),
             btc_rpc_master_wallet.clone(),
+            btc_rpc_master_wallet.clone(),
             btc_rpc_master_wallet,
             btc_rpcs,
             "test_redeem_succeeds",
@@ -166,6 +167,7 @@ async fn test_replace_succeeds() {
         let _vault_id_manager = VaultIdManager::from_map(
             new_vault_provider.clone(),
             new_btc_rpc_master_wallet.clone(),
+            new_btc_rpc_master_wallet.clone(),
             new_btc_rpc_master_wallet,
             btc_rpcs,
             "test_replace_succeeds1",
@@ -179,6 +181,7 @@ async fn test_replace_succeeds() {
         let old_btc_rpc_master_wallet = btc_rpc.clone();
         let vault_id_manager = VaultIdManager::from_map(
             old_vault_provider.clone(),
+            old_btc_rpc_master_wallet.clone(),
             old_btc_rpc_master_wallet.clone(),
             old_btc_rpc_master_wallet,
             btc_rpcs,
@@ -354,6 +357,7 @@ async fn test_cancellation_succeeds() {
         let new_btc_rpc_master_wallet = btc_rpc.clone();
         let vault_id_manager = VaultIdManager::from_map(
             new_vault_provider.clone(),
+            new_btc_rpc_master_wallet.clone(),
             new_btc_rpc_master_wallet.clone(),
             new_btc_rpc_master_wallet,
             btc_rpcs,
@@ -624,6 +628,7 @@ async fn test_automatic_issue_execution_succeeds() {
         let vault_id_manager = VaultIdManager::from_map(
             vault2_provider.clone(),
             btc_rpc_master_wallet.clone(),
+            btc_rpc_master_wallet.clone(),
             btc_rpc_master_wallet,
             btc_rpcs,
             "test_automatic_issue_execution_succeeds",
@@ -724,6 +729,7 @@ async fn test_automatic_issue_execution_succeeds_with_big_transaction() {
         let vault_id_manager = VaultIdManager::from_map(
             vault2_provider.clone(),
             btc_rpc_master_wallet.clone(),
+            btc_rpc_master_wallet.clone(),
             btc_rpc_master_wallet,
             btc_rpcs,
             "test_automatic_issue_execution_succeeds_with_big_transaction",
@@ -812,6 +818,7 @@ async fn test_execute_open_requests_succeeds() {
         let btc_rpc_master_wallet = btc_rpc.clone();
         let vault_id_manager = VaultIdManager::from_map(
             vault_provider.clone(),
+            btc_rpc_master_wallet.clone(),
             btc_rpc_master_wallet.clone(),
             btc_rpc_master_wallet,
             btc_rpcs,
@@ -1213,6 +1220,7 @@ mod test_with_bitcoind {
             let btc_rpc_master_wallet = btc_rpc.clone();
             let vault_id_manager = VaultIdManager::from_map(
                 vault_provider.clone(),
+                btc_rpc_master_wallet.clone(),
                 btc_rpc_master_wallet.clone(),
                 btc_rpc_master_wallet,
                 btc_rpcs,


### PR DESCRIPTION
Reverts [this](https://github.com/interlay/interbtc-clients/pull/518) fix which did not work as expected. Here is a recap of the problem with the failed migration which occurred on Kintsugi:

- wallet migration imports all addresses with funds to shared wallet
- pruned nodes use electrs to reimport all issue address funds
- some of these issue addresses are already spent
- new wallet doesn't have context of spent utxos because it is pruned and we can't rescan

The only way to fix this now is by sweeping the funds and then only reimporting funds after the sweeping transaction:

- sweep all funds from currency specific wallet to shared
- remove all pruned funds from shared wallet
  - this is to recover the shared wallet from the failed migration
  - it assumes new issues are already recorded by bitcoind
- sweep again all funds back into shared wallet and record height
- future rescans via electrs should only happen for addresses after the sweep height

This is a best-effort solution, I will run some manual tests to verify the correctness but I would highlight to pruned nodes that a full reindex / rescan using a full node (not-pruned) is the best way to be sure to funds are missed.
