### PR TITLE
fix: allow oracles composed of different feeds

### DIFF
--- a/oracle/src/error.rs
+++ b/oracle/src/error.rs
@@ -24,9 +24,8 @@ pub enum ConfigError<Currency> {
 }
 
 #[derive(Error, Debug)]
-#[error("{feed}: {pair} => {error}")]
+#[error("{pair} => {error}")]
 pub struct PriceConfigError<Currency> {
-    pub(crate) feed: FeedName,
     pub(crate) pair: CurrencyPair<Currency>,
     pub(crate) error: ConfigError<Currency>,
 }

--- a/oracle/src/feeds/dia_fair_price.rs
+++ b/oracle/src/feeds/dia_fair_price.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::single_char_pattern)]
 use super::{get_http, PriceFeed};
-use crate::{config::CurrencyStore, currency::*, Error};
+use crate::{config::CurrencyStore, currency::*, feeds::DiaApi, Error};
 use async_trait::async_trait;
 use clap::Parser;
 use reqwest::Url;


### PR DESCRIPTION
Corresponding new configs: https://github.com/interlay/interlay-devops/pull/15
Output with new config:

Interlay:
`[2023-11-16T22:03:17Z DEBUG oracle] Collected prices: [CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("INTR") }, price: 1464167.4304740096 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("DOT") }, price: 6706.458319361545 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("USDT") }, price: 36036.036036036036 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("VDOT") }, price: 5515.5137103648785 }]`

Kintsugi:
`[2023-11-16T22:04:22Z DEBUG oracle] Collected prices: [CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("KINT") }, price: 92165.89861751153 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("KSM") }, price: 1440.341072766031 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("LKSM") }, price: 10024.057738572576 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("USDT") }, price: 35997.120230381566 }, CurrencyPairAndPrice { pair: CurrencyPair { base: Symbol("BTC"), quote: Symbol("VKSM") }, price: 1127.2984307348295 }]`